### PR TITLE
New encodable format for StitchDocument schema

### DIFF
--- a/Sources/StitchSchemaKit/README.md
+++ b/Sources/StitchSchemaKit/README.md
@@ -16,9 +16,6 @@ Follow these instructions if you plan to make a change to any `SwiftData` entity
     * Also do a find + replace on the old previous version. If V3 is the new version, replace `_V1` with `_V2`.
 6. Add new `StitchSchemaVersion`, incrementing the number. Fix compiler warners for missing case in switch statements.
 7. Update the type aliases at the top of the SchemaVersions.swift file.
-8. The last most-recent `StitchDocument` needs to have its `Transferable` implementation removed. Complete these steps from the old version:
-    1. Remove the `Transferable` inheritance at the class definition inside the enum. 
-    2. Remove `transferRepresentation` requirement static property.
     
 ### Supporting New Schema Entities
 1. Update `StitchDocumentMigratable` with a new dictionary of `PersistentIdentifier` ID's using the following format:

--- a/Sources/StitchSchemaKit/V1/Document_V1/StitchDocument_V1.swift
+++ b/Sources/StitchSchemaKit/V1/Document_V1/StitchDocument_V1.swift
@@ -16,7 +16,6 @@ public enum StitchDocument_V1: StitchSchemaVersionable {
     public typealias NodeEntitySchema = NodeEntity_V1
     // MARK: - end
 
-    // TODO: transferable
     public struct StitchDocument: StitchVersionedCodable {
         public var projectId: ProjectId
         public var name: String
@@ -60,13 +59,6 @@ public enum StitchDocument_V1: StitchSchemaVersionable {
             self.commentBoxesDict = commentBoxesDict
             self.cameraSettings = cameraSettings
         }
-        
-        // MARK: remove `transferRepresentation` from older `StitchDocument` versions
-//        static var transferRepresentation: some TransferRepresentation {
-//            FileRepresentation(contentType: .stitchDocument,
-//                               exporting: Self.exportDocument,
-//                               importing: Self.importDocument)
-//        }
     }
 }
 


### PR DESCRIPTION
This PR improves the versioning structure to pin version numbers to the file itself, allowing data.json to use a modifiable JSON structure