### PR TITLE
Add Pack and Unpack patches for various types

### DIFF
--- a/Sources/StitchSchemaKit/V2/Patch_V2.swift
+++ b/Sources/StitchSchemaKit/V2/Patch_V2.swift
@@ -162,7 +162,17 @@ public enum Patch_V2: StitchSchemaVersionable {
              jsonToShape,
              shapeToCommands = "Shape To Commands",
              commandsToShape = "Commands To Shape",
-             mouse
+             mouse,
+             sizePack = "Size Pack",
+             sizeUnpack = "Size Unpack",
+             positionPack = "Position Pack",
+             positionUnpack = "Position Unpack",
+             point3DPack = "Point 3D Pack",
+             point3DUnpack = "Point 3D Unpack",
+             point4DPack = "Point 4D Pack",
+             point4DUnpack = "Point 4D Unpack",
+             matrixTransformPack = "Matrix Transform Pack",
+             matrixTransformUnpack = "Matrix Transform Unpack"
     }
 
 }


### PR DESCRIPTION
Per regular codebase these are all the types we use for pack and unpack. 

Note that we're keeping the .pack and .unpack patches for now. Those will need a separate migration.

<img width="687" alt="Screenshot 2024-02-23 at 3 54 29 PM" src="https://github.com/vpl-codesign/StitchSchemaKit/assets/18562836/6444e3ff-5c5d-4634-afa9-c08d0209299b">
