### PR TITLE
From LayerNodeEntity_V13 on, use previous values for Shadow ports and SF Symbol port

### DIFF
--- a/Sources/StitchSchemaKit/V13/Node/Layer/LayerNodeEntity_V13.swift
+++ b/Sources/StitchSchemaKit/V13/Node/Layer/LayerNodeEntity_V13.swift
@@ -375,12 +375,12 @@ extension LayerNodeEntity_V13.LayerNodeEntity: StitchVersionedCodable {
                   startRadiusPort: NodeConnectionType_V13.NodeConnectionType(previousInstance: previousInstance.startRadiusPort),
                   endRadiusPort: NodeConnectionType_V13.NodeConnectionType(previousInstance: previousInstance.endRadiusPort),
                   
-                  shadowColorPort: NodeConnectionType_V13.NodeConnectionType.values([]),
-                  shadowOpacityPort: NodeConnectionType_V13.NodeConnectionType.values([]),
-                  shadowRadiusPort: NodeConnectionType_V13.NodeConnectionType.values([]),
-                  shadowOffsetPort: NodeConnectionType_V13.NodeConnectionType.values([]),
-                  
-                  sfSymbolPort: NodeConnectionType_V13.NodeConnectionType.values([]),
+                  // V12 first introduced these ports, so on V13 we do have previous values
+                  shadowColorPort: NodeConnectionType_V13.NodeConnectionType(previousInstance: previousInstance.shadowColorPort),
+                  shadowOpacityPort: NodeConnectionType_V13.NodeConnectionType(previousInstance: previousInstance.shadowOpacityPort),
+                  shadowRadiusPort: NodeConnectionType_V13.NodeConnectionType(previousInstance: previousInstance.shadowRadiusPort),
+                  shadowOffsetPort: NodeConnectionType_V13.NodeConnectionType(previousInstance: previousInstance.shadowOffsetPort),
+                  sfSymbolPort: NodeConnectionType_V13.NodeConnectionType(previousInstance: previousInstance.sfSymbolPort),
                   
                   hasSidebarVisibility: previousInstance.hasSidebarVisibility,
                   layerGroupId: previousInstance.layerGroupId,

--- a/Sources/StitchSchemaKit/V14/PortValueTypes/StrokeLineCap_V14.swift
+++ b/Sources/StitchSchemaKit/V14/PortValueTypes/StrokeLineCap_V14.swift
@@ -22,6 +22,13 @@ public enum StrokeLineCap_V14: StitchSchemaVersionable {
 
 extension StrokeLineCap_V14.StrokeLineCap: StitchVersionedCodable {
     public init(previousInstance: StrokeLineCap_V14.PreviousInstance) {
-        fatalError()
+        switch previousInstance {
+        case .butt:
+            self = .butt
+        case .square:
+            self = .square
+        case .round:
+            self = .round
+        }
     }
 }

--- a/Sources/StitchSchemaKit/V14/PortValueTypes/StrokeLineJoin_V14.swift
+++ b/Sources/StitchSchemaKit/V14/PortValueTypes/StrokeLineJoin_V14.swift
@@ -22,6 +22,13 @@ public enum StrokeLineJoin_V14: StitchSchemaVersionable {
 
 extension StrokeLineJoin_V14.StrokeLineJoin: StitchVersionedCodable {
     public init(previousInstance: StrokeLineJoin_V14.PreviousInstance) {
-        fatalError()
+        switch previousInstance {
+        case .bevel:
+            self = .bevel
+        case .miter:
+            self = .miter
+        case .round:
+            self = .round
+        }
     }
 }


### PR DESCRIPTION
Also updates migration logic for Stroke Line Join and Cap; though for some reason we didn't seem to be hitting the fatalError() when we were migrating...