### PR TITLE
Make LayerInputType CaseIterable

### DIFF
--- a/Sources/StitchSchemaKit/V18/NodePort/LayerInputType_V18.swift
+++ b/Sources/StitchSchemaKit/V18/NodePort/LayerInputType_V18.swift
@@ -13,7 +13,7 @@ public enum LayerInputType_V18: StitchSchemaVersionable {
     public typealias PreviousInstance = LayerInputType_V17.LayerInputType
     // MARK: - endif
     
-    public enum LayerInputType {
+    public enum LayerInputType: CaseIterable {
         // Required everywhere
         case position
         case size


### PR DESCRIPTION
Helpful for making sure we've handled all possible input types.