### PR TITLE
Fixed NodeKind versioning

### DIFF
--- a/Sources/StitchSchemaKit/V1/Node/NodeKind_V1.swift
+++ b/Sources/StitchSchemaKit/V1/Node/NodeKind_V1.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V1: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V1
     public typealias PreviousInstance = Self.NodeKind
+    public typealias Patch = Patch_V1.Patch
+    public typealias Layer = Layer_V1.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {

--- a/Sources/StitchSchemaKit/V10/Node/NodeKind_V10.swift
+++ b/Sources/StitchSchemaKit/V10/Node/NodeKind_V10.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V10: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V10
     public typealias PreviousInstance = NodeKind_V9.NodeKind
+    public typealias Patch = Patch_V10.Patch
+    public typealias Layer = Layer_V10.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V10.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V11/Node/NodeKind_V11.swift
+++ b/Sources/StitchSchemaKit/V11/Node/NodeKind_V11.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V11: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V11
     public typealias PreviousInstance = NodeKind_V10.NodeKind
+    public typealias Patch = Patch_V11.Patch
+    public typealias Layer = Layer_V11.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V11.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V12/Node/NodeKind_V12.swift
+++ b/Sources/StitchSchemaKit/V12/Node/NodeKind_V12.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V12: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V12
     public typealias PreviousInstance = NodeKind_V11.NodeKind
+    public typealias Patch = Patch_V12.Patch
+    public typealias Layer = Layer_V12.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V12.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V13/Node/NodeKind_V13.swift
+++ b/Sources/StitchSchemaKit/V13/Node/NodeKind_V13.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V13: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V13
     public typealias PreviousInstance = NodeKind_V12.NodeKind
+    public typealias Patch = Patch_V13.Patch
+    public typealias Layer = Layer_V13.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V13.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V14/Node/NodeKind_V14.swift
+++ b/Sources/StitchSchemaKit/V14/Node/NodeKind_V14.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V14: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V14
     public typealias PreviousInstance = NodeKind_V13.NodeKind
+    public typealias Patch = Patch_V14.Patch
+    public typealias Layer = Layer_V14.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V14.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V15/Node/NodeKind_V15.swift
+++ b/Sources/StitchSchemaKit/V15/Node/NodeKind_V15.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V15: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V15
     public typealias PreviousInstance = NodeKind_V14.NodeKind
+    public typealias Patch = Patch_V15.Patch
+    public typealias Layer = Layer_V15.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V15.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V16/Node/NodeKind_V16.swift
+++ b/Sources/StitchSchemaKit/V16/Node/NodeKind_V16.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V16: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V16
     public typealias PreviousInstance = NodeKind_V15.NodeKind
+    public typealias Patch = Patch_V16.Patch
+    public typealias Layer = Layer_V16.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V16.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V17/Node/NodeKind_V17.swift
+++ b/Sources/StitchSchemaKit/V17/Node/NodeKind_V17.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V17: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V17
     public typealias PreviousInstance = NodeKind_V16.NodeKind
+    public typealias Patch = Patch_V17.Patch
+    public typealias Layer = Layer_V17.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V17.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V18/Node/NodeKind_V18.swift
+++ b/Sources/StitchSchemaKit/V18/Node/NodeKind_V18.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V18: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V18
     public typealias PreviousInstance = NodeKind_V17.NodeKind
+    public typealias Patch = Patch_V18.Patch
+    public typealias Layer = Layer_V18.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V18.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V19/Node/NodeKind_V19.swift
+++ b/Sources/StitchSchemaKit/V19/Node/NodeKind_V19.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V19: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V19
     public typealias PreviousInstance = NodeKind_V18.NodeKind
+    public typealias Patch = Patch_V19.Patch
+    public typealias Layer = Layer_V19.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V19.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V2/Node/NodeKind_V2.swift
+++ b/Sources/StitchSchemaKit/V2/Node/NodeKind_V2.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V2: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V2
     public typealias PreviousInstance = NodeKind_V1.NodeKind
+    public typealias Patch = Patch_V2.Patch
+    public typealias Layer = Layer_V2.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V2.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V20/Node/NodeKind_V20.swift
+++ b/Sources/StitchSchemaKit/V20/Node/NodeKind_V20.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V20: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V20
     public typealias PreviousInstance = NodeKind_V19.NodeKind
+    public typealias Patch = Patch_V20.Patch
+    public typealias Layer = Layer_V20.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V20.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V21/Node/NodeKind_V21.swift
+++ b/Sources/StitchSchemaKit/V21/Node/NodeKind_V21.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V21: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V21
     public typealias PreviousInstance = NodeKind_V20.NodeKind
+    public typealias Patch = Patch_V21.Patch
+    public typealias Layer = Layer_V21.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V21.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V22/Node/NodeKind_V22.swift
+++ b/Sources/StitchSchemaKit/V22/Node/NodeKind_V22.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V22: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V22
     public typealias PreviousInstance = NodeKind_V21.NodeKind
+    public typealias Patch = Patch_V22.Patch
+    public typealias Layer = Layer_V22.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V22.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V23/Node/NodeKind_V23.swift
+++ b/Sources/StitchSchemaKit/V23/Node/NodeKind_V23.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V23: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V23
     public typealias PreviousInstance = NodeKind_V22.NodeKind
+    public typealias Patch = Patch_V23.Patch
+    public typealias Layer = Layer_V23.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V23.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V3/Node/NodeKind_V3.swift
+++ b/Sources/StitchSchemaKit/V3/Node/NodeKind_V3.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V3: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V3
     public typealias PreviousInstance = NodeKind_V2.NodeKind
+    public typealias Patch = Patch_V3.Patch
+    public typealias Layer = Layer_V3.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V3.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V4/Node/NodeKind_V4.swift
+++ b/Sources/StitchSchemaKit/V4/Node/NodeKind_V4.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V4: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V4
     public typealias PreviousInstance = NodeKind_V3.NodeKind
+    public typealias Patch = Patch_V4.Patch
+    public typealias Layer = Layer_V4.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V4.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V5/Node/NodeKind_V5.swift
+++ b/Sources/StitchSchemaKit/V5/Node/NodeKind_V5.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V5: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V5
     public typealias PreviousInstance = NodeKind_V4.NodeKind
+    public typealias Patch = Patch_V5.Patch
+    public typealias Layer = Layer_V5.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,11 +25,12 @@ extension NodeKind_V5.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }
     }
 }
+

--- a/Sources/StitchSchemaKit/V6/Node/NodeKind_V6.swift
+++ b/Sources/StitchSchemaKit/V6/Node/NodeKind_V6.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V6: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V6
     public typealias PreviousInstance = NodeKind_V5.NodeKind
+    public typealias Patch = Patch_V6.Patch
+    public typealias Layer = Layer_V6.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V6.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V7/Node/NodeKind_V7.swift
+++ b/Sources/StitchSchemaKit/V7/Node/NodeKind_V7.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V7: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V7
     public typealias PreviousInstance = NodeKind_V6.NodeKind
+    public typealias Patch = Patch_V7.Patch
+    public typealias Layer = Layer_V7.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V7.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V8/Node/NodeKind_V8.swift
+++ b/Sources/StitchSchemaKit/V8/Node/NodeKind_V8.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V8: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V8
     public typealias PreviousInstance = NodeKind_V7.NodeKind
+    public typealias Patch = Patch_V8.Patch
+    public typealias Layer = Layer_V8.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V8.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }

--- a/Sources/StitchSchemaKit/V9/Node/NodeKind_V9.swift
+++ b/Sources/StitchSchemaKit/V9/Node/NodeKind_V9.swift
@@ -11,6 +11,8 @@ public enum NodeKind_V9: StitchSchemaVersionable {
     // MARK: - ensure versions are correct
     static var version: StitchSchemaVersion = StitchSchemaVersion._V9
     public typealias PreviousInstance = NodeKind_V8.NodeKind
+    public typealias Patch = Patch_V9.Patch
+    public typealias Layer = Layer_V9.Layer
     // MARK: - endif
     
     public enum NodeKind: Codable, Equatable, Hashable {
@@ -23,9 +25,9 @@ extension NodeKind_V9.NodeKind: StitchVersionedCodable {
         switch previousInstance {
             
         case .patch(let value):
-            self = .patch(value)
+            self = .patch(.init(previousInstance: value))
         case .layer(let value):
-            self = .layer(value)
+            self = .layer(.init(previousInstance: value))
         case .group:
             self = .group
         }


### PR DESCRIPTION
Fixes issue where `NodeKind` type aliases were pointing to the most recent version.