### PR TITLE
Support for Stitch AI types - take 2

### DIFF
--- a/Sources/StitchSchemaKit/SSKError.swift
+++ b/Sources/StitchSchemaKit/SSKError.swift
@@ -1,0 +1,12 @@
+//
+//  SSKError.swift
+//  StitchSchemaKit
+//
+//  Created by Elliot Boschwitz on 6/3/25.
+//
+
+public enum SSKError: Error {
+    case nextVersionNotFound(StitchSchemaVersion)
+    case migrationFailed(any StitchVersionedCodable)
+    case castingToNewestVersionFailed(any StitchVersionedCodable)
+}

--- a/Sources/StitchSchemaKit/SchemaVersions.swift
+++ b/Sources/StitchSchemaKit/SchemaVersions.swift
@@ -111,10 +111,13 @@ public typealias CurrentMaterialThickness = MaterialThickness_V32
 public typealias CurrentJavaScriptNodeSettings = JavaScriptNodeSettings_V32
 public typealias CurrentJavaScriptPortDefinition = JavaScriptPortDefinition_V32
 public typealias CurrentKeyboardType = KeyboardType_V32
+public typealias CurrentPatchOrLayer = PatchOrLayer_V32
+public typealias CurrentNodeKindDescribable = NodeKindDescribable_V32
+public typealias CurrentStitchAINodeKindDescription = StitchAINodeKindDescription_V32
 
 // MARK: - end
 
-public enum StitchSchemaVersion: Int, VersionType {
+public enum StitchSchemaVersion: Int, VersionType, Sendable {
     case _V1 = 1
     case _V2 = 2
     case _V3 = 3

--- a/Sources/StitchSchemaKit/V31/Layer_V31.swift
+++ b/Sources/StitchSchemaKit/V31/Layer_V31.swift
@@ -101,6 +101,123 @@ extension Layer_V31.Layer: StitchVersionedCodable {
         case .cone:
             self = .cone
         }
-        
+    }
+}
+
+extension Layer_V31.Layer: NodeKindDescribable_V31.NodeKindDescribable {
+    public static let titleDisplay = "Layer"
+    
+    public func defaultDisplayTitle() -> String {
+        switch self {
+        case .model3D:
+            return "3D Model"
+        case .text:
+            return "Text"
+        case .oval:
+            return "Oval"
+        case .rectangle:
+            return "Rectangle"
+        case .image:
+            return "Image"
+        case .group:
+            return "Group"
+        case .video:
+            return "Video"
+        case .realityView:
+            return "Reality View"
+        case .shape:
+            return "Shape"
+        case .colorFill:
+            return "Color Fill"
+        case .hitArea:
+            return "Hit Area"
+        case .canvasSketch:
+            return "Canvas Sketch"
+        case .textField:
+            return "Text Field"
+        case .map:
+            return "Map"
+        case .progressIndicator:
+            return "Progress Indicator"
+        case .sfSymbol:
+            return "SF Symbol"
+        case .material:
+            return "Material"
+        case .switchLayer:
+            return "Toggle Switch"
+        case .linearGradient:
+            return "Linear Gradient"
+        case .radialGradient:
+            return "Radial Gradient"
+        case .angularGradient:
+            return "Angular Gradient"
+        case .videoStreaming:
+            return "Video Streaming"
+        case .box:
+            return "Box"
+        case .sphere:
+            return "Sphere"
+        case .cylinder:
+            return "Cylinder"
+        case .cone:
+            return "Cone"
+        }
+    }
+    
+    public var aiNodeDescription: String {
+        switch self {
+        case .text:
+            return "displays a text string."
+        case .oval:
+            return "displays an oval."
+        case .rectangle:
+            return "displays a rectangle."
+        case .shape:
+            return "takes a Shape and displays it."
+        case .colorFill:
+            return "displays a color fill."
+        case .image:
+            return "displays an image."
+        case .video:
+            return "displays a video."
+        case .videoStreaming:
+            return "displays a streaming video."
+        case .realityView:
+            return "displays AR scene output."
+        case .canvasSketch:
+            return "draw custom shapes interactively."
+        case .model3D:
+            return "Layer - display a 3D model asset (of a USDZ file type) in the preview window."
+        case .box:
+            return "A box 3D shape, which can be used inside a Reality View."
+        case .sphere:
+            return "A sphere 3D shape, which can be used inside a Reality View."
+        case .cylinder:
+            return "A cylinder 3D shape, which can be used inside a Reality View."
+        case .cone:
+            return "A cylinder 3D shape, which can be used inside a Reality View."
+        case .group:
+            return "A container layer that can hold multiple child layers."
+        case .hitArea:
+            return "A layer that defines an interactive area for touch input."
+        case .textField:
+            return "An editable text input field."
+        case .progressIndicator:
+            return "Displays a progress indicator or loading state."
+        case .switchLayer:
+            return "A toggle switch control layer."
+        case .linearGradient:
+            return "Creates a linear gradient."
+        case .radialGradient:
+            return "-Creates a radial gradient."
+        case .angularGradient:
+            return "Creates an angular gradient."
+        case .material:
+            return "A Material Effect layer."
+        case .map:
+            return "The Map node will display an Apple Maps UI in the preview window."
+        case .sfSymbol:
+            return "Creates an SF Symbol."
+        }
     }
 }

--- a/Sources/StitchSchemaKit/V31/Node/NodeKindDescribable_V31.swift
+++ b/Sources/StitchSchemaKit/V31/Node/NodeKindDescribable_V31.swift
@@ -1,0 +1,36 @@
+//
+//  Untitled.swift
+//  StitchSchemaKit
+//
+//  Created by Elliot Boschwitz on 6/2/25.
+//
+
+import Foundation
+
+public enum NodeKindDescribable_V31 {
+    // MARK: - ensure versions are correct
+    public static let version: StitchSchemaVersion = StitchSchemaVersion._V31
+    // MARK: - endif
+    
+    public protocol NodeKindDescribable: CaseIterable {
+        func defaultDisplayTitle() -> String
+        
+        var aiNodeDescription: String { get }
+        
+        static var titleDisplay: String { get }
+    }
+}
+
+extension NodeKindDescribable_V31.NodeKindDescribable {
+    public var aiDisplayTitle: String {
+        Self.toCamelCase(self.defaultDisplayTitle()) + " || \(Self.titleDisplay)"
+    }
+
+    private static func toCamelCase(_ sentence: String) -> String {
+        let words = sentence.components(separatedBy: " ")
+        let camelCaseString = words.enumerated().map { index, word in
+            index == 0 ? word.lowercased() : word.capitalized
+        }.joined()
+        return camelCaseString
+    }
+}

--- a/Sources/StitchSchemaKit/V31/Node/PatchOrLayer_V31.swift
+++ b/Sources/StitchSchemaKit/V31/Node/PatchOrLayer_V31.swift
@@ -1,0 +1,48 @@
+//
+//  PatchOrLayer_V31.swift
+//  StitchSchemaKit
+//
+//  Created by Elliot Boschwitz on 6/1/25.
+//
+
+import Foundation
+
+public enum PatchOrLayer_V31: StitchSchemaVersionable {
+    // MARK: - ensure versions are correct
+    public static let version: StitchSchemaVersion = StitchSchemaVersion._V31
+    public typealias PreviousInstance = Self.PatchOrLayer
+    public typealias Patch = Patch_V31.Patch
+    public typealias Layer = Layer_V31.Layer
+    // MARK: - endif
+    
+    public enum PatchOrLayer: Codable, Hashable {
+        case patch(Patch), layer(Layer)
+    }
+}
+
+extension PatchOrLayer_V31.PatchOrLayer: StitchVersionedCodable {
+    public init(previousInstance: PatchOrLayer_V31.PreviousInstance) {
+        fatalError()
+    }
+}
+
+extension PatchOrLayer_V31.PatchOrLayer {
+    var description: String {
+        switch self {
+        case .patch(let patch):
+            return patch.defaultDisplayTitle()
+        case .layer(let layer):
+            return layer.defaultDisplayTitle()
+        }
+    }
+    
+    public var asLLMStepNodeName: String {
+        switch self {
+        case .patch(let x):
+            // e.g. Patch.squareRoot -> "Square Root" -> "squareRoot || Patch"
+            return x.aiDisplayTitle
+        case .layer(let x):
+            return x.aiDisplayTitle
+        }
+    }
+}

--- a/Sources/StitchSchemaKit/V31/Node/StitchAINodeKindDescription_V31.swift
+++ b/Sources/StitchSchemaKit/V31/Node/StitchAINodeKindDescription_V31.swift
@@ -1,0 +1,35 @@
+//
+//  StitchAINodeKindDescription_V31.swift
+//  StitchSchemaKit
+//
+//  Created by Elliot Boschwitz on 6/2/25.
+//
+
+import Foundation
+
+public enum StitchAINodeKindDescription_V31: StitchSchemaVersionable {
+    // MARK: - ensure versions are correct
+    public static let version: StitchSchemaVersion = StitchSchemaVersion._V31
+    public typealias PreviousInstance = Self.StitchAINodeKindDescription
+    // MARK: - endif
+    
+    public struct StitchAINodeKindDescription {
+        public var nodeKind: String
+        public var description: String
+    }
+}
+
+extension StitchAINodeKindDescription_V31.StitchAINodeKindDescription: StitchVersionedCodable {
+    public init(previousInstance: StitchAINodeKindDescription_V31.PreviousInstance) {
+        fatalError()
+    }
+}
+
+extension NodeKindDescribable_V31.NodeKindDescribable {
+    public static var allAiDescriptions: [StitchAINodeKindDescription_V31.StitchAINodeKindDescription] {
+        Self.allCases.map {
+            .init(nodeKind: $0.aiDisplayTitle,
+                  description: $0.aiNodeDescription)
+        }
+    }
+}

--- a/Sources/StitchSchemaKit/V31/NodePort/Layer/LayerInputPort_V31.swift
+++ b/Sources/StitchSchemaKit/V31/NodePort/Layer/LayerInputPort_V31.swift
@@ -685,4 +685,252 @@ extension LayerInputPort_V31.LayerInputPort {
             return \.isScrollAutoPort
         }
     }
+    
+    public func label(useShortLabel: Bool = false) -> String {
+        switch self {
+        case .position:
+            return "Position"
+        case .size:
+            return "Size"
+        case .scale:
+            return "Scale"
+        case .anchoring:
+            return "Anchoring"
+        case .startAnchor:
+            return "Start Anchor"
+        case .endAnchor:
+            return "End Anchor"
+        case .opacity:
+            return "Opacity"
+        case .zIndex:
+            return "Z Index"
+        case .masks:
+            return "Masks"
+        case .color:
+            return "Color"
+        case .startColor:
+            return "Start Color"
+        case .endColor:
+            return "End Color"
+        case .rotationX:
+            return "Rotation X"
+        case .rotationY:
+            return "Rotation Y"
+        case .rotationZ:
+            return "Rotation Z"
+        case .lineColor:
+            return "Line Color"
+        case .lineWidth:
+            return "Line Width"
+        case .blur:
+            return "Blur"
+        case .blendMode:
+            return "Blend Mode"
+        case .brightness:
+            return "Brightness"
+        case .colorInvert:
+            return "Color Invert"
+        case .contrast:
+            return "Contrast"
+        case .hueRotation:
+            return "Hue Rotation"
+        case .saturation:
+            return "Saturation"
+        case .pivot:
+            return "Pivot"
+        case .enabled:
+            return "Enable"
+        case .blurRadius:
+            return "Blur Radius"
+        case .backgroundColor:
+            return "Background Color"
+        case .isClipped:
+            return "Clipped"
+        case .orientation: // LayerGroup orientation
+            return "Layout"
+        case .padding:
+            return "Padding"
+        case .setupMode:
+            return "Setup Mode"
+        case .cameraDirection:
+            return "Camera Direction"
+        case .isCameraEnabled:
+            return "Camera Enabled"
+        case .isShadowsEnabled:
+            return "Shadows Enabled"
+            
+        case .shape:
+            return "Shape"
+            
+        case .strokePosition:
+            return useShortLabel ? "Position" : "Stroke Position"
+        case .strokeWidth:
+            return useShortLabel ? "Width" : "Stroke Width"
+        case .strokeColor:
+            return useShortLabel ? "Color" : "Stroke Color"
+        case .strokeStart:
+            return useShortLabel ? "Start" : "Stroke Start"
+        case .strokeEnd:
+            return useShortLabel ? "End" : "Stroke End"
+        case .strokeLineCap:
+            return useShortLabel ? "Line Cap" : "Stroke Line Cap"
+        case .strokeLineJoin:
+            return useShortLabel ? "Line Join" : "Stroke Line Join"
+        case .coordinateSystem:
+            return "Coordinate System"
+            
+        case .canvasLineColor:
+            return "Line Color"
+        case .canvasLineWidth:
+            return "Line Width"
+        case .cornerRadius:
+            return "Corner Radius"
+        case .text:
+            return "Text"
+        case .fontSize:
+            return "Font Size"
+        case .textAlignment:
+            return useShortLabel ? "Alignment" : "Text Alignment"
+        case .verticalAlignment:
+            return useShortLabel ? "Vertical Align." : "Vertical Text Alignment"
+        case .textDecoration:
+            return useShortLabel ? "Decoration" : "Text Decoration"
+        case .textFont:
+            return useShortLabel ? "Font" : "Text Font"
+        case .image:
+            return "Image"
+        case .video:
+            return "Video"
+        case .fitStyle:
+            return "Fit Style"
+        case .clipped:
+            return "Clipped"
+        case .isAnimating:
+            return "Animating"
+        case .progressIndicatorStyle:
+            return "Style"
+        case .progress:
+            return "Progress"
+        case .model3D:
+            return "3D Model"
+        case .mapType:
+            return "Map Style"
+        case .mapLatLong:
+            return "Lat/Long"
+        case .mapSpan:
+            return "Span"
+        case .isSwitchToggled:
+            return "Toggle"
+        case .placeholderText:
+            return "Placeholder"
+        case .centerAnchor:
+            return "Center Anchor"
+        case .startAngle:
+            return "Start Angle"
+        case .endAngle:
+            return "End Angle"
+        case .startRadius:
+            return "Start Radius"
+        case .endRadius:
+            return "End Radius"
+        case .shadowColor:
+            return useShortLabel ? "Color" : "Shadow Color"
+        case .shadowOpacity:
+            return useShortLabel ? "Opacity" : "Shadow Opacity"
+        case .shadowRadius:
+            return useShortLabel ? "Radius" : "Shadow Radius"
+        case .shadowOffset:
+            return useShortLabel ? "Offset" : "Shadow Offset"
+        case .sfSymbol:
+            return "SF Symbol"
+            
+        case .videoURL:
+            return "Video URL"
+        case .volume:
+            return "Volume"
+            
+        case .spacingBetweenGridColumns:
+            return "Column Spacing"
+        case .spacingBetweenGridRows:
+            return "Row Spacing"
+        case .itemAlignmentWithinGridCell:
+            return "Cell Anchoring"
+            
+        case .widthAxis:
+            return "Width Axis"
+        case .heightAxis:
+            return "Height Axis"
+        case .contentMode:
+            return "Content Mode"
+        case .minSize:
+            return "Min Size"
+        case .maxSize:
+            return "Max Size"
+        case .spacing:
+            return "Spacing"
+        case .sizingScenario:
+            return "Sizing"
+        case .isPinned:
+            return "Pinned"
+        case .pinTo:
+            return "Pin To"
+        case .pinAnchor:
+            return useShortLabel ? "Anchor" : "Pin Anchor"
+        case .pinOffset:
+            return useShortLabel ? "Offset" : "Pin Offset"
+        
+        case .layerPadding:
+            return useShortLabel ? "Padding" : "Layer Padding"
+        case .layerMargin:
+            return useShortLabel ? "Margin" : "Layer Margin"
+        case .offsetInGroup:
+            return useShortLabel ? "Offset" : "Offset in Group"
+        case .layerGroupAlignment:
+            return useShortLabel ? "Alignment" : "Children Alignment"
+        case .materialThickness:
+            return "Material"
+        case .deviceAppearance:
+            return useShortLabel ? "Appearance" : "Device Appearance"
+        case .scrollContentSize:
+            return useShortLabel ? "Content" : "Content Size"
+        case .scrollXEnabled:
+            return "Scroll X Enabled"
+        case .scrollJumpToXStyle:
+            return "Jump Style X"
+        case .scrollJumpToX:
+            return "Jump to X"
+        case .scrollJumpToXLocation:
+            return "Jump Position X"
+        case .scrollYEnabled:
+            return "Scroll Y Enabled"
+        case .scrollJumpToYStyle:
+            return "Jump Style Y"
+        case .scrollJumpToY:
+            return "Jump to Y"
+        case .scrollJumpToYLocation:
+            return "Jump Position Y"
+        case .anchorEntity:
+            return "Anchor Entity"
+        case .isEntityAnimating:
+            return "Animating"
+        case .translation3DEnabled:
+            return "Translation"
+        case .rotation3DEnabled:
+            return "Rotation"
+        case .scale3DEnabled:
+            return "Scale"
+        case .isMetallic:
+            return "Metallic"
+        case .transform3D:
+            return "3D Transform"
+        case .size3D:
+            return "Size 3D"
+        case .radius3D:
+            return "Radius"
+        case .height3D:
+            return "Height"
+        case .isScrollAuto:
+            return "Auto Scroll"
+        }
+    }
 }

--- a/Sources/StitchSchemaKit/V31/Patch_V31.swift
+++ b/Sources/StitchSchemaKit/V31/Patch_V31.swift
@@ -513,3 +513,622 @@ extension Patch_V31.Patch: StitchVersionedCodable {
         }
     }
 }
+
+extension Patch_V31.Patch: NodeKindDescribable_V31.NodeKindDescribable {
+    public static let titleDisplay = "Patch"
+    
+    public func defaultDisplayTitle() -> String {
+        switch self {
+        case .splitter:
+            return "Value"
+        case .flipSwitch:
+            return "Switch"
+        case .arcTan2:
+            return "Arc Tan 2"
+        case .coreMLClassify:
+            return "Image Classification"
+        case .coreMLDetection:
+            return "Object Detection"
+        case .hslColor:
+            return "HSL Color"
+        case .colorToHSL:
+            return "Color to HSL"
+        case .rgba:
+            return "RGB Color"
+        case .colorToRGB:
+            return "Color to RGB"
+        case .arRaycasting:
+            return "Raycasting"
+        case .base64StringToImage:
+            return "Base64 to Image"
+        case .imageToBase64String:
+            return "Image to Base64"
+        case .whenPrototypeStarts:
+            return "On Prototype Start"
+        case .jsonToShape:
+            return "JSON to Shape"
+        case .jsonArray:
+            return "JSON Array"
+        case .jsonObject:
+            return "JSON Object"
+        case .arAnchor:
+            return "AR Anchor"
+        case .add:
+            return "Add"
+        case .convertPosition:
+            return "Convert Position"
+        case .dragInteraction:
+            return "Drag Interaction"
+        case .pressInteraction:
+            return "Press Interaction"
+        case .scrollInteraction:
+            return "Legacy Scroll Interaction"
+        case .repeatingPulse:
+            return "Repeating Pulse"
+        case .delay:
+            return "Delay"
+        case .pack:
+            return "Pack"
+        case .unpack:
+            return "Unpack"
+        case .counter:
+            return "Counter"
+        case .multiply:
+            return "Multiply"
+        case .optionPicker:
+            return "Option Picker"
+        case .loop:
+            return "Loop"
+        case .time:
+            return "Time"
+        case .deviceTime:
+            return "Device Time"
+        case .location:
+            return "Location"
+        case .random:
+            return "Random"
+        case .greaterOrEqual:
+            return "Greater or Equal"
+        case .lessThanOrEqual:
+            return "Less Than or Equal"
+        case .equals:
+            return "Equals"
+        case .restartPrototype:
+            return "Restart Prototype"
+        case .divide:
+            return "Divide"
+        case .or:
+            return "Or"
+        case .and:
+            return "And"
+        case .not:
+            return  "Not"
+        case .springAnimation:
+            return "Spring Animation"
+        case .popAnimation:
+            return "Pop Animation"
+        case .bouncyConverter:
+            return "Bouncy Converter"
+        case .optionSwitch:
+            return "Option Switch"
+        case .pulseOnChange:
+            return "Pulse on Change"
+        case .pulse:
+            return "Pulse"
+        case .classicAnimation:
+            return "Classic Animation"
+        case .cubicBezierAnimation:
+            return "Cubic Bezier Animation"
+        case .curve:
+            return "Curve"
+        case .cubicBezierCurve:
+            return "Cubic Bezier Curve"
+        case .repeatingAnimation:
+            return "Repeating Animation"
+        case .loopBuilder:
+            return "Loop Builder"
+        case .loopInsert:
+            return "Loop Insert"
+        case .transition:
+            return "Transition"
+        case .imageImport:
+            return "Image Import"
+        case .cameraFeed:
+            return "Camera Feed"
+        case .sampleAndHold:
+            return "Sample and Hold"
+        case .grayscale:
+            return "Grayscale"
+        case .loopSelect:
+            return "Loop Select"
+        case .videoImport:
+            return "Video Import"
+        case .sampleRange:
+            return "Sample Range"
+        case .soundImport:
+            return "Sound Import"
+        case .speaker:
+            return "Speaker"
+        case .microphone:
+            return "Microphone"
+        case .networkRequest:
+            return "Network Request"
+        case .valueForKey:
+            return "Value for Key"
+        case .valueAtIndex:
+            return "Value at Index"
+        case .loopOverArray:
+            return "Loop Over Array"
+        case .setValueForKey:
+            return "Set Value for Key"
+        case .arrayAppend:
+            return "Array Append"
+        case .arrayCount:
+            return "Array Count"
+        case .arrayJoin:
+            return "Array Join"
+        case .arrayReverse:
+            return "Array Reverse"
+        case .arraySort:
+            return "Array Sort"
+        case .getKeys:
+            return "Get Keys"
+        case .indexOf:
+            return "Index Of"
+        case .subarray:
+            return "Sub Array"
+        case .valueAtPath:
+            return "Value at Path"
+        case .deviceMotion:
+            return "Device Motion"
+        case .deviceInfo:
+            return "Device Info"
+        case .smoothValue:
+            return "Smooth Value"
+        case .velocity:
+            return "Velocity"
+        case .clip:
+            return "Clip"
+        case .max:
+            return "Max"
+        case .mod:
+            return "Mod"
+        case .absoluteValue:
+            return "Absolute Value"
+        case .round:
+            return "Round"
+        case .progress:
+            return "Progress"
+        case .reverseProgress:
+            return "Reverse Progress"
+        case .wirelessBroadcaster:
+            return "Wireless Broadcaster"
+        case .wirelessReceiver:
+            return "Wireless Receiver"
+        case .sine:
+            return "Sine"
+        case .cosine:
+            return "Cosine"
+        case .hapticFeedback:
+            return "Haptic Feedback"
+        case .soulver:
+            return "Soulver"
+        case .optionEquals:
+            return "Option Equals"
+        case .subtract:
+            return "Subtract"
+        case .squareRoot:
+            return "Square Root"
+        case .length:
+            return "Length"
+        case .min:
+            return "Min"
+        case .power:
+            return "Power"
+        case .equalsExactly:
+            return "Equals Exactly"
+        case .greaterThan:
+            return "Greater Than"
+        case .lessThan:
+            return "Less Than"
+        case .colorToHex:
+            return "Color to Hex"
+        case .hexColor:
+            return "Hex Color"
+        case .splitText:
+            return "Split Text"
+        case .textEndsWith:
+            return "Text Ends With"
+        case .textLength:
+            return "Text Length"
+        case .textReplace:
+            return "Text Replace"
+        case .textStartsWith:
+            return "Text Starts With"
+        case .textTransform:
+            return "Text Transform"
+        case .trimText:
+            return "Trim Text"
+        case .dateAndTimeFormatter:
+            return "Date And Time Formatter"
+        case .stopwatch:
+            return "Stopwatch"
+        case .optionSender:
+            return "Option Sender"
+        case .any:
+            return "Any"
+        case .loopCount:
+            return "Loop Count"
+        case .loopDedupe:
+            return "Loop Dedupe"
+        case .loopFilter:
+            return "Loop Filter"
+        case .loopOptionSwitch:
+            return "Loop Option Switch"
+        case .loopRemove:
+            return "Loop Remove"
+        case .loopReverse:
+            return "Loop Reverse"
+        case .loopShuffle:
+            return "Loop Shuffle"
+        case .loopSum:
+            return "Loop Sum"
+        case .loopToArray:
+            return "Loop to Array"
+        case .runningTotal:
+            return "Running Total"
+        case .layerInfo:
+            return "Layer Info"
+        case .triangleShape:
+            return "Triangle Shape"
+        case .circleShape:
+            return "Circle Shape"
+        case .ovalShape:
+            return "Oval Shape"
+        case .roundedRectangleShape:
+            return "Rounded Rectangle Shape"
+        case .union:
+            return "Union"
+        case .keyboard:
+            return "Keyboard"
+        case .shapeToCommands:
+            return "Shape to Commands"
+        case .commandsToShape:
+            return "Commands to Shape"
+        case .mouse:
+            return "Mouse"
+        case .qrCodeDetection:
+            return "QR Code Detection"
+        case .delayOne:
+            return "Delay 1"
+            // TODO: assume that rawValue for all patches added will have properly capitalized display-value, and so just use `default: return self.rawValue`
+        case .sizePack, .sizeUnpack, .positionPack, .positionUnpack, .point3DPack, .point3DUnpack, .point4DPack, .point4DUnpack, .transformPack, .transformUnpack, .closePath, .moveToPack, .lineToPack, .curveToPack, .curveToUnpack, .mathExpression, .springFromDurationAndBounce, .springFromResponseAndDampingRatio, .springFromSettlingDurationAndDampingRatio:
+            return self.rawValue
+        }
+    }
+    
+    public var aiNodeDescription: String {
+        switch self {
+        case .add:
+            return "Adds two numbers together."
+        case .subtract:
+            return "Subtracts one number from another."
+        case .multiply:
+            return "Multiplies two numbers together."
+        case .divide:
+            return "Divides one number by another."
+        case .mod:
+            return "Calculates the remainder of a division."
+        case .power:
+            return "Raises a number to the power of another."
+        case .squareRoot:
+            return "Calculates the square root of a number."
+        case .absoluteValue:
+            return "Finds the absolute value of a number."
+        case .round:
+            return "Rounds a number to the nearest integer."
+        case .max:
+            return "Finds the maximum of two numbers."
+        case .min:
+            return "Finds the minimum of two numbers."
+        case .length:
+            return "Calculates the length of a collection."
+        case .arcTan2:
+            return "Calculates the arctangent of a quotient."
+        case .sine:
+            return "Calculates the sine of an angle."
+        case .cosine:
+            return "Calculates the cosine of an angle."
+        case .clip:
+            return "Clips a value to a specified range."
+        case .or:
+            return "Logical OR operation."
+        case .and:
+            return "Logical AND operation."
+        case .not:
+            return "Logical NOT operation."
+        case .equals:
+            return "Checks if two values are equal."
+        case .equalsExactly:
+            return "Checks if two values are exactly equal."
+        case .greaterThan:
+            return "Checks if one value is greater than another."
+        case .greaterOrEqual:
+            return "Checks if one value is greater or equal to another."
+        case .lessThan:
+            return "Checks if one value is less than another."
+        case .lessThanOrEqual:
+            return "Checks if one value is less than or equal to another."
+        case .splitText:
+            return "Splits text into parts."
+        case .textLength:
+            return "Calculates the length of a text string."
+        case .textReplace:
+            return "Replaces text within a string."
+        case .textStartsWith:
+            return "Checks if text starts with a specific substring."
+        case .textEndsWith:
+            return "Checks if text ends with a specific substring."
+        case .textTransform:
+            return "Transforms text into a different format."
+        case .trimText:
+            return "Removes whitespace from the beginning and end of a text string."
+        case .time:
+            return "Returns number of seconds and frames since a prototype started."
+        case .dateAndTimeFormatter:
+            return "creates a human-readable date/time value from a time in seconds."
+        case .stopwatch:
+            return "measures elapsed time in seconds."
+        case .delay:
+            return "delays a value by a specified number of seconds."
+        case .delayOne:
+            return "delays incoming value by 1 frame."
+        case .imageImport:
+            return "imports an image asset."
+        case .videoImport:
+            return "imports a video asset."
+        case .soundImport:
+            return "imports an audio asset."
+        case .qrCodeDetection:
+            return "detects the value of a QR code from an image or video."
+        case .coreMLClassify:
+            return "performs image classification on an image or video."
+        case .coreMLDetection:
+            return "detects objects in an image or video."
+        case .cameraFeed:
+            return "creates a live camera feed."
+        case .deviceInfo:
+            return "gets info of the running device."
+        case .hapticFeedback:
+            return "generates haptic feedback."
+        case .keyboard:
+            return "handles keyboard input."
+        case .mouse:
+            return "handles mouse input."
+        case .microphone:
+            return "handles microphone input."
+        case .speaker:
+            return "handles audio speaker output."
+        case .dragInteraction:
+            return "detects a drag interaction."
+        case .pressInteraction:
+            return "detects a press interaction."
+        case .location:
+            return "gets the current location."
+        case .circleShape:
+            return "generates a circle shape."
+        case .ovalShape:
+            return "generates an oval shape."
+        case .roundedRectangleShape:
+            return "generates a rounded rectangle shape."
+        case .triangleShape:
+            return "generates a triangle shape."
+        case .shapeToCommands:
+            return "takes a shape as input, outputs the commands to generate the shape."
+        case .commandsToShape:
+            return "generates a shape from a given loop of shape commands."
+        case .transformPack:
+            return "packs inputs into a transform."
+        case .transformUnpack:
+            return "unpacks a transform."
+        case .moveToPack:
+            return "packs a position into a MoveTo shape command."
+        case .lineToPack:
+            return "packs a position into a LineTo shape command."
+        case .closePath:
+            return "ClosePath shape command."
+        case .base64StringToImage:
+            return "converts a base64 string to an image."
+        case .imageToBase64String:
+            return "converts an image to a base64 string."
+        case .colorToHSL:
+            return "converts a color to HSL components."
+        case .colorToRGB:
+            return "converts a color to RGB components."
+        case .colorToHex:
+            return "converts a color to a hex string."
+        case .hslColor:
+            return "generates a color from HSL components."
+        case .hexColor:
+            return "converts a hex string to a color."
+        case .grayscale:
+            return "applies grayscale effect to image/video."
+        case .splitter:
+            return "stores a value."
+        case .random:
+            return "generates a random value."
+        case .progress:
+            return "calculates progress value."
+        case .reverseProgress:
+            return "calculates inverse progress."
+        case .convertPosition:
+            return "converts position values between layers."
+        case .velocity:
+            return "measures velocity over time."
+        case .soulver:
+            return "evaluates plain-text math expressions."
+        case .whenPrototypeStarts:
+            return "fires pulse when prototype starts."
+        case .valueForKey:
+            return "extracts a value from JSON by key."
+        case .valueAtIndex:
+            return "extracts a value from JSON by index."
+        case .valueAtPath:
+            return "extracts a value from JSON by path."
+        case .pack:
+            return "creates a new value from inputs."
+        case .unpack:
+            return "splits a value into components."
+        case .sampleAndHold:
+            return "stores a value until new one is received."
+        case .sampleRange:
+            return "samples a range of values."
+        case .smoothValue:
+            return "smoothes input value."
+        case .runningTotal:
+            return "continuously sums values."
+        case .jsonToShape:
+            return "creates a Shape from JSON."
+        case .jsonArray:
+            return "creates a JSON array from inputs."
+        case .jsonObject:
+            return "creates a JSON object from key-value pairs."
+        case .bouncyConverter:
+            return "Converts bounce and duration values to spring animation parameters."
+        case .loopBuilder:
+            return "Creates a new loop with specified values."
+        case .loopFilter:
+            return "Filters elements in a loop based on a condition."
+        case .loopSelect:
+            return "Selects specific elements from a loop."
+        case .loopCount:
+            return "Counts the number of elements in a loop."
+        case .loopDedupe:
+            return "Removes duplicate elements from a loop."
+        case .loopOptionSwitch:
+            return "Switches between different loop options."
+        case .loopOverArray:
+            return "Iterates over elements in an array."
+        case .loopToArray:
+            return "Converts a loop into an array."
+        case .transition:
+            return "Controls transitions between states."
+        case .optionEquals:
+            return "Checks if an option equals a specific value."
+        case .curve:
+            return "Defines an animation curve."
+        case .cubicBezierCurve:
+            return "Creates a cubic bezier curve for animations."
+        case .any:
+            return "Returns true if any input is true."
+        case .rgba:
+            return "Creates a color from RGBA components."
+        case .arrayJoin:
+            return "Joins array elements into a string."
+        case .getKeys:
+            return "Gets all keys from an object."
+        case .indexOf:
+            return "Gets the index of an element in an array."
+        case .positionUnpack:
+            return "Unpacks a position into X and Y components."
+        case .point3DUnpack:
+            return "Unpacks a 3D point into X, Y, and Z components."
+        case .point4DUnpack:
+            return "Unpacks a 4D point into X, Y, Z, and W components."
+        case .mathExpression:
+            return "Evaluates a mathematical expression."
+        case .setValueForKey:
+            return "Sets a value for a specified key in an object."
+        case .springAnimation:
+            return "Creates an animation based off of the physical model of a spring"
+        case .popAnimation:
+            return " Animates a value using a spring effect."
+        case .classicAnimation:
+            return "Animates a number using a standard animation curve."
+        case .cubicBezierAnimation:
+            return "Creates custom animation curves by defining two control points"
+        case .repeatingAnimation:
+            return "Repeatedly animates a number."
+        case .pulse:
+            return "Outputs a pulse event when it's toggled on or off."
+        case .pulseOnChange:
+            return "The Pulse On Change node outputs a pulse if an input value comes in that i different from the specified value."
+        case .repeatingPulse:
+            return "A node that will fire a pulse at a defined interval."
+        case .union:
+            return "Combines two or more shapes to generate a new shape."
+        case .arrayAppend:
+            return " This node appends to the end of the provided array."
+        case .arrayCount:
+            return "This node returns the number of items in an array."
+        case .subarray:
+            return "Returns a subarray from a given array."
+        case .arraySort:
+            return "This node sorts the array in ascending order."
+        case .arrayReverse:
+            return "This node reverses the order of the items in the array."
+        case .scrollInteraction:
+            return "Adds scroll interaction to a specified layer."
+        case .arAnchor:
+            return "Creates an AR anchor from a 3D model and an ARTransform. Represents the positio and orientation of a 3D item in the physical environment."
+        case .arRaycasting:
+            return "Returns a 3D location in physical space that corresponds to a given 2D location o the screen."
+        case .deviceTime:
+            return "Returns the current time of the device your prototype is running on."
+        case .deviceMotion:
+            return "Returns the acceleration and rotation values of the device the patch is running on."
+        case .wirelessBroadcaster:
+            return "Sends a value to a selected Wireless Receiver node. Useful for organizing large complicated projects by replacing cables between patches."
+        case .wirelessReceiver:
+            return "-Used with the Wireless Broadcaster node to route values across the graph. Useful fo organizing large, complicated projects."
+        case .restartPrototype:
+            return "A node that will restart the state of your prototype. All inputs and outputs of th nodes on your graph will be reset."
+        case .optionPicker:
+            return "The Option Picker node lets you cycle through and select one of N inputs to use a the output. Multiple inputs can be added and removed from the node, and it can be configured to work with a variety of node types."
+        case .optionSender:
+            return "Used to pick an output to send a value to. Multiple value types can be used wit this node."
+        case .optionSwitch:
+            return "Used to control two or more states with an index value. N number of inputs can b added to the node."
+        case .counter:
+            return "Counter that can be incremented, decremented, or set to a specified value. Starts at 0."
+        case .flipSwitch:
+            return "A node that will flip between an On and Off state whenever a pulse is received."
+        case .loop:
+            return "Generate a loop of indices. For example, an input of 3 outputs a loop of [0, 1, 2]."
+        case .loopInsert:
+            return "Insert a new value at a particular index in a loop."
+        case .networkRequest:
+            return "The Network Request node allows you to make HTTP GET and POST requests to an endpoint. Results are returned as JSON."
+        case .loopRemove:
+            return "Removes a value from a specified index in a loop."
+        case .loopReverse:
+            return "Reverse the order of the values in a loop"
+        case .loopShuffle:
+            return "Randomly reorders the values in a loop."
+        case .loopSum:
+            return "Calculates the sum of every value in a loop."
+        case .layerInfo:
+            return "Returns information about a specified layer."
+        case .sizePack:
+            return "Packs two Layer Dimension inputs to a single Layer Size output."
+        case .sizeUnpack:
+            return "Unpacks a single Layer Size input to two Layer Size outputs."
+        case .positionPack:
+            return "Packs two Number inputs to a single Position output."
+        case .point3DPack:
+            return "Packs three Number inputs to a single Point3D output."
+        case .point4DPack:
+            return "Packs four Number inputs to a single Point4D output."
+        case .curveToPack:
+            return "Packs Point, CurveTo and CurveFrom position inputs into a CurveTo ShapeCommand."
+        case .curveToUnpack:
+            return "Unpack packs CurveTo ShapeCommand into a Point, CurveTo and CurveFrom position outputs."
+        case .springFromDurationAndBounce:
+            return "Convert duration and bounce values to mass, stiffness and damping for a Spring Animation node."
+        case .springFromResponseAndDampingRatio:
+            return "Convert response and damping ratio to mass, stiffness and damping for a Spring Animation node."
+        case .springFromSettlingDurationAndDampingRatio:
+            return "Convert settling duration and damping ratio to mass, stiffness and damping for a Spring Animation node."
+        }
+    }
+}

--- a/Sources/StitchSchemaKit/V31/PortValueTypes/LayerDimension_V31.swift
+++ b/Sources/StitchSchemaKit/V31/PortValueTypes/LayerDimension_V31.swift
@@ -51,3 +51,27 @@ extension LayerDimension_V31.LayerDimension: StitchVersionedCodable {
         }
     }
 }
+
+extension LayerDimension_V31.LayerDimension: CustomStringConvertible {
+    public static let AUTO_SIZE_STRING = "auto"
+    public static let FILL_SIZE_STRING = "fill"
+    public static let HUG_SIZE_STRING = "hug"
+    
+    // MARK: string coercison causes perf loss (GitHub issue #3120)
+    public var description: String {
+        switch self {
+        case .auto:
+            return Self.AUTO_SIZE_STRING
+        case .parentPercent(let x):
+            //            return "\(x.coerceToUserFriendlyString)%"
+            return "\(x.description)%"
+        case .number(let x):
+            //            return x.coerceToUserFriendlyString
+            return x.description
+        case .fill:
+            return Self.FILL_SIZE_STRING
+        case .hug:
+            return Self.HUG_SIZE_STRING
+        }
+    }
+}

--- a/Sources/StitchSchemaKit/V31/UserVisibleType_V31.swift
+++ b/Sources/StitchSchemaKit/V31/UserVisibleType_V31.swift
@@ -194,3 +194,146 @@ extension UserVisibleType_V31.UserVisibleType: StitchVersionedCodable {
         }
     }
 }
+
+extension UserVisibleType_V31.UserVisibleType {
+    public init?(llmString: String) {
+        guard let match = Self.allCases.first(where: {
+            $0.asLLMStepNodeType == Self.toCamelCase(llmString)
+        }) else {
+            return nil
+        }
+        
+        self = match
+    }
+    
+    // TODO: our OpenAI schema does not define all possible node-types, and those node types that we do define use camelCase
+    // TODO: some node types use human-readable strings ("Sizing Scenario"), not camelCase ("sizingScenario") as their raw value; so can't use `NodeType(rawValue:)` constructor
+    public var asLLMStepNodeType: String {
+        Self.toCamelCase(self.display)
+    }
+    
+    public var display: String {
+        switch self {
+        case .int:
+            return "Int"
+        case .string:
+            return "String"
+        case .bool:
+            return "Bool"
+        case .color:
+            return "Color"
+        case .number:
+            return "Number"
+        case .layerDimension:
+            return "Layer Dimension"
+        case .size:
+            return "Size"
+        case .position:
+            return "Position"
+        case .point3D:
+            return "3D Point"
+        case .point4D:
+            return "4D Point"
+        case .transform:
+            return "Transform"
+        case .plane:
+            return "Plane"
+        case .pulse:
+            return "Pulse"
+        case .media:
+            return "Media"
+        case .json:
+            return "JSON"
+        case .networkRequestType:
+            return "Network Request Type"
+        case .none:
+            return "None"
+        case .anchoring:
+            return "Anchor"
+        case .cameraDirection:
+            return "Camera Direction"
+        case .interactionId:
+            return "Layer"
+        case .scrollMode:
+            return "Scroll Mode"
+        case .textAlignment:
+            return "Text Horizontal Alignment"
+        case .textVerticalAlignment:
+            return "Text Vertical Alignment"
+        case .fitStyle:
+            return "Fit"
+        case .animationCurve:
+            return "Animation Curve"
+        case .lightType:
+            return "Light Type"
+        case .layerStroke:
+            return "Layer Stroke"
+        case .textTransform:
+            return "Text Transform"
+        case .dateAndTimeFormat:
+            return "Date and Time Format"
+        case .shape:
+            return "Shape"
+        case .scrollJumpStyle:
+            return "Scroll Jump Style"
+        case .scrollDecelerationRate:
+            return "Scroll Deceleration Rate"
+        case .delayStyle:
+            return "Delay Style"
+        case .shapeCoordinates:
+            return "Shape Coordinates"
+        case .shapeCommand:
+            return "Shape Command"
+        case .shapeCommandType:
+            return "Shape Command Type"
+        case .orientation:
+            return "Orientation"
+        case .cameraOrientation:
+            return "Camera Orientation"
+        case .deviceOrientation:
+            return "Device Orientation"
+        case .vnImageCropOption:
+            return "Image Crop & Scale"
+        case .textDecoration:
+            return "Text Decoration"
+        case .textFont:
+            return "Text Font"
+        case .blendMode:
+            return "Blend Mode"
+        case .mapType:
+            return "Map Type"
+        case .progressIndicatorStyle:
+            return "Progress Style"
+        case .mobileHapticStyle:
+            return "Haptic Style"
+        case .strokeLineCap:
+            return "Stroke Line Cap"
+        case .strokeLineJoin:
+            return "Stroke Line Join"
+        case .contentMode:
+            return "Content Mode"
+        case .spacing:
+            return "Spacing"
+        case .padding:
+            return "Padding"
+        case .sizingScenario:
+            return "Sizing Scenario"
+        case .pinToId:
+            return "Pin To ID"
+        case .materialThickness:
+            return "Materialize Thickness"
+        case .deviceAppearance:
+            return "Device Appearance"
+        case .anchorEntity:
+            return "Anchor Entity"
+        }
+    }
+    
+    private static func toCamelCase(_ sentence: String) -> String {
+        let words = sentence.components(separatedBy: " ")
+        let camelCaseString = words.enumerated().map { index, word in
+            index == 0 ? word.lowercased() : word.capitalized
+        }.joined()
+        return camelCaseString
+    }
+}

--- a/Sources/StitchSchemaKit/V32/Layer_V32.swift
+++ b/Sources/StitchSchemaKit/V32/Layer_V32.swift
@@ -101,6 +101,124 @@ extension Layer_V32.Layer: StitchVersionedCodable {
         case .cone:
             self = .cone
         }
-        
     }
 }
+
+extension Layer_V32.Layer: NodeKindDescribable_V32.NodeKindDescribable {
+    public static let titleDisplay = "Layer"
+    
+    public func defaultDisplayTitle() -> String {
+        switch self {
+        case .model3D:
+            return "3D Model"
+        case .text:
+            return "Text"
+        case .oval:
+            return "Oval"
+        case .rectangle:
+            return "Rectangle"
+        case .image:
+            return "Image"
+        case .group:
+            return "Group"
+        case .video:
+            return "Video"
+        case .realityView:
+            return "Reality View"
+        case .shape:
+            return "Shape"
+        case .colorFill:
+            return "Color Fill"
+        case .hitArea:
+            return "Hit Area"
+        case .canvasSketch:
+            return "Canvas Sketch"
+        case .textField:
+            return "Text Field"
+        case .map:
+            return "Map"
+        case .progressIndicator:
+            return "Progress Indicator"
+        case .sfSymbol:
+            return "SF Symbol"
+        case .material:
+            return "Material"
+        case .switchLayer:
+            return "Toggle Switch"
+        case .linearGradient:
+            return "Linear Gradient"
+        case .radialGradient:
+            return "Radial Gradient"
+        case .angularGradient:
+            return "Angular Gradient"
+        case .videoStreaming:
+            return "Video Streaming"
+        case .box:
+            return "Box"
+        case .sphere:
+            return "Sphere"
+        case .cylinder:
+            return "Cylinder"
+        case .cone:
+            return "Cone"
+        }
+    }
+    
+    public var aiNodeDescription: String {
+        switch self {
+        case .text:
+            return "displays a text string."
+        case .oval:
+            return "displays an oval."
+        case .rectangle:
+            return "displays a rectangle."
+        case .shape:
+            return "takes a Shape and displays it."
+        case .colorFill:
+            return "displays a color fill."
+        case .image:
+            return "displays an image."
+        case .video:
+            return "displays a video."
+        case .videoStreaming:
+            return "displays a streaming video."
+        case .realityView:
+            return "displays AR scene output."
+        case .canvasSketch:
+            return "draw custom shapes interactively."
+        case .model3D:
+            return "Layer - display a 3D model asset (of a USDZ file type) in the preview window."
+        case .box:
+            return "A box 3D shape, which can be used inside a Reality View."
+        case .sphere:
+            return "A sphere 3D shape, which can be used inside a Reality View."
+        case .cylinder:
+            return "A cylinder 3D shape, which can be used inside a Reality View."
+        case .cone:
+            return "A cylinder 3D shape, which can be used inside a Reality View."
+        case .group:
+            return "A container layer that can hold multiple child layers."
+        case .hitArea:
+            return "A layer that defines an interactive area for touch input."
+        case .textField:
+            return "An editable text input field."
+        case .progressIndicator:
+            return "Displays a progress indicator or loading state."
+        case .switchLayer:
+            return "A toggle switch control layer."
+        case .linearGradient:
+            return "Creates a linear gradient."
+        case .radialGradient:
+            return "-Creates a radial gradient."
+        case .angularGradient:
+            return "Creates an angular gradient."
+        case .material:
+            return "A Material Effect layer."
+        case .map:
+            return "The Map node will display an Apple Maps UI in the preview window."
+        case .sfSymbol:
+            return "Creates an SF Symbol."
+        }
+    }
+}
+

--- a/Sources/StitchSchemaKit/V32/Node/NodeKindDescribable_V32.swift
+++ b/Sources/StitchSchemaKit/V32/Node/NodeKindDescribable_V32.swift
@@ -1,0 +1,36 @@
+//
+//  NodeKindDescribable_V32.swift
+//  StitchSchemaKit
+//
+//  Created by Elliot Boschwitz on 6/2/25.
+//
+
+import Foundation
+
+public enum NodeKindDescribable_V32 {
+    // MARK: - ensure versions are correct
+    public static let version: StitchSchemaVersion = StitchSchemaVersion._V32
+    // MARK: - endif
+    
+    public protocol NodeKindDescribable: CaseIterable {
+        func defaultDisplayTitle() -> String
+        
+        var aiNodeDescription: String { get }
+        
+        static var titleDisplay: String { get }
+    }
+}
+
+extension NodeKindDescribable_V32.NodeKindDescribable {
+    public var aiDisplayTitle: String {
+        Self.toCamelCase(self.defaultDisplayTitle()) + " || \(Self.titleDisplay)"
+    }
+
+    private static func toCamelCase(_ sentence: String) -> String {
+        let words = sentence.components(separatedBy: " ")
+        let camelCaseString = words.enumerated().map { index, word in
+            index == 0 ? word.lowercased() : word.capitalized
+        }.joined()
+        return camelCaseString
+    }
+}

--- a/Sources/StitchSchemaKit/V32/Node/PatchOrLayer_V32.swift
+++ b/Sources/StitchSchemaKit/V32/Node/PatchOrLayer_V32.swift
@@ -1,0 +1,53 @@
+//
+//  PatchOrLayer_V32.swift
+//  StitchSchemaKit
+//
+//  Created by Elliot Boschwitz on 6/1/25.
+//
+
+import Foundation
+
+public enum PatchOrLayer_V32: StitchSchemaVersionable {
+    // MARK: - ensure versions are correct
+    public static let version: StitchSchemaVersion = StitchSchemaVersion._V32
+    public typealias PreviousInstance = PatchOrLayer_V31.PatchOrLayer
+    public typealias Patch = Patch_V32.Patch
+    public typealias Layer = Layer_V32.Layer
+    // MARK: - endif
+    
+    public enum PatchOrLayer: Codable, Hashable {
+        case patch(Patch), layer(Layer)
+    }
+}
+
+extension PatchOrLayer_V32.PatchOrLayer: StitchVersionedCodable {
+    public init(previousInstance: PatchOrLayer_V32.PreviousInstance) {
+        switch previousInstance {
+        case .patch(let patch):
+            self = .patch(.init(previousInstance: patch))
+        case .layer(let layer):
+            self = .layer(.init(previousInstance: layer))
+        }
+    }
+}
+
+extension PatchOrLayer_V32.PatchOrLayer {
+    var description: String {
+        switch self {
+        case .patch(let patch):
+            return patch.defaultDisplayTitle()
+        case .layer(let layer):
+            return layer.defaultDisplayTitle()
+        }
+    }
+    
+    public var asLLMStepNodeName: String {
+        switch self {
+        case .patch(let x):
+            // e.g. Patch.squareRoot -> "Square Root" -> "squareRoot || Patch"
+            return x.aiDisplayTitle
+        case .layer(let x):
+            return x.aiDisplayTitle
+        }
+    }
+}

--- a/Sources/StitchSchemaKit/V32/Node/StitchAINodeKindDescription_V32.swift
+++ b/Sources/StitchSchemaKit/V32/Node/StitchAINodeKindDescription_V32.swift
@@ -1,0 +1,36 @@
+//
+//  StitchAINodeKindDescription_V32.swift
+//  StitchSchemaKit
+//
+//  Created by Elliot Boschwitz on 6/2/25.
+//
+
+import Foundation
+
+public enum StitchAINodeKindDescription_V32: StitchSchemaVersionable {
+    // MARK: - ensure versions are correct
+    public static let version: StitchSchemaVersion = StitchSchemaVersion._V31
+    public typealias PreviousInstance = StitchAINodeKindDescription_V31.StitchAINodeKindDescription
+    // MARK: - endif
+    
+    public struct StitchAINodeKindDescription {
+        public var nodeKind: String
+        public var description: String
+    }
+}
+
+extension StitchAINodeKindDescription_V32.StitchAINodeKindDescription: StitchVersionedCodable {
+    public init(previousInstance: StitchAINodeKindDescription_V32.PreviousInstance) {
+        self = .init(nodeKind: previousInstance.nodeKind,
+                     description: previousInstance.description)
+    }
+}
+
+extension NodeKindDescribable_V32.NodeKindDescribable {
+    public static var allAiDescriptions: [StitchAINodeKindDescription_V32.StitchAINodeKindDescription] {
+        Self.allCases.map {
+            .init(nodeKind: $0.aiDisplayTitle,
+                  description: $0.aiNodeDescription)
+        }
+    }
+}

--- a/Sources/StitchSchemaKit/V32/NodePort/Layer/LayerInputPort_V32.swift
+++ b/Sources/StitchSchemaKit/V32/NodePort/Layer/LayerInputPort_V32.swift
@@ -708,4 +708,252 @@ extension LayerInputPort_V32.LayerInputPort {
             return \.keyboardTypePort
         }
     }
+    
+    public func label(useShortLabel: Bool = false) -> String {
+        switch self {
+        case .position:
+            return "Position"
+        case .size:
+            return "Size"
+        case .scale:
+            return "Scale"
+        case .anchoring:
+            return "Anchoring"
+        case .startAnchor:
+            return "Start Anchor"
+        case .endAnchor:
+            return "End Anchor"
+        case .opacity:
+            return "Opacity"
+        case .zIndex:
+            return "Z Index"
+        case .masks:
+            return "Masks"
+        case .color:
+            return "Color"
+        case .startColor:
+            return "Start Color"
+        case .endColor:
+            return "End Color"
+        case .rotationX:
+            return "Rotation X"
+        case .rotationY:
+            return "Rotation Y"
+        case .rotationZ:
+            return "Rotation Z"
+        case .lineColor:
+            return "Line Color"
+        case .lineWidth:
+            return "Line Width"
+        case .blur:
+            return "Blur"
+        case .blendMode:
+            return "Blend Mode"
+        case .brightness:
+            return "Brightness"
+        case .colorInvert:
+            return "Color Invert"
+        case .contrast:
+            return "Contrast"
+        case .hueRotation:
+            return "Hue Rotation"
+        case .saturation:
+            return "Saturation"
+        case .pivot:
+            return "Pivot"
+        case .enabled:
+            return "Enable"
+        case .blurRadius:
+            return "Blur Radius"
+        case .backgroundColor:
+            return "Background Color"
+        case .isClipped:
+            return "Clipped"
+        case .orientation: // LayerGroup orientation
+            return "Layout"
+        case .padding:
+            return "Padding"
+        case .setupMode:
+            return "Setup Mode"
+        case .cameraDirection:
+            return "Camera Direction"
+        case .isCameraEnabled:
+            return "Camera Enabled"
+        case .isShadowsEnabled:
+            return "Shadows Enabled"
+            
+        case .shape:
+            return "Shape"
+            
+        case .strokePosition:
+            return useShortLabel ? "Position" : "Stroke Position"
+        case .strokeWidth:
+            return useShortLabel ? "Width" : "Stroke Width"
+        case .strokeColor:
+            return useShortLabel ? "Color" : "Stroke Color"
+        case .strokeStart:
+            return useShortLabel ? "Start" : "Stroke Start"
+        case .strokeEnd:
+            return useShortLabel ? "End" : "Stroke End"
+        case .strokeLineCap:
+            return useShortLabel ? "Line Cap" : "Stroke Line Cap"
+        case .strokeLineJoin:
+            return useShortLabel ? "Line Join" : "Stroke Line Join"
+        case .coordinateSystem:
+            return "Coordinate System"
+            
+        case .canvasLineColor:
+            return "Line Color"
+        case .canvasLineWidth:
+            return "Line Width"
+        case .cornerRadius:
+            return "Corner Radius"
+        case .text:
+            return "Text"
+        case .fontSize:
+            return "Font Size"
+        case .textAlignment:
+            return useShortLabel ? "Alignment" : "Text Alignment"
+        case .verticalAlignment:
+            return useShortLabel ? "Vertical Align." : "Vertical Text Alignment"
+        case .textDecoration:
+            return useShortLabel ? "Decoration" : "Text Decoration"
+        case .textFont:
+            return useShortLabel ? "Font" : "Text Font"
+        case .image:
+            return "Image"
+        case .video:
+            return "Video"
+        case .fitStyle:
+            return "Fit Style"
+        case .clipped:
+            return "Clipped"
+        case .isAnimating:
+            return "Animating"
+        case .progressIndicatorStyle:
+            return "Style"
+        case .progress:
+            return "Progress"
+        case .model3D:
+            return "3D Model"
+        case .mapType:
+            return "Map Style"
+        case .mapLatLong:
+            return "Lat/Long"
+        case .mapSpan:
+            return "Span"
+        case .isSwitchToggled:
+            return "Toggle"
+        case .placeholderText:
+            return "Placeholder"
+        case .centerAnchor:
+            return "Center Anchor"
+        case .startAngle:
+            return "Start Angle"
+        case .endAngle:
+            return "End Angle"
+        case .startRadius:
+            return "Start Radius"
+        case .endRadius:
+            return "End Radius"
+        case .shadowColor:
+            return useShortLabel ? "Color" : "Shadow Color"
+        case .shadowOpacity:
+            return useShortLabel ? "Opacity" : "Shadow Opacity"
+        case .shadowRadius:
+            return useShortLabel ? "Radius" : "Shadow Radius"
+        case .shadowOffset:
+            return useShortLabel ? "Offset" : "Shadow Offset"
+        case .sfSymbol:
+            return "SF Symbol"
+            
+        case .videoURL:
+            return "Video URL"
+        case .volume:
+            return "Volume"
+            
+        case .spacingBetweenGridColumns:
+            return "Column Spacing"
+        case .spacingBetweenGridRows:
+            return "Row Spacing"
+        case .itemAlignmentWithinGridCell:
+            return "Cell Anchoring"
+            
+        case .widthAxis:
+            return "Width Axis"
+        case .heightAxis:
+            return "Height Axis"
+        case .contentMode:
+            return "Content Mode"
+        case .minSize:
+            return "Min Size"
+        case .maxSize:
+            return "Max Size"
+        case .spacing:
+            return "Spacing"
+        case .sizingScenario:
+            return "Sizing"
+        case .isPinned:
+            return "Pinned"
+        case .pinTo:
+            return "Pin To"
+        case .pinAnchor:
+            return useShortLabel ? "Anchor" : "Pin Anchor"
+        case .pinOffset:
+            return useShortLabel ? "Offset" : "Pin Offset"
+        
+        case .layerPadding:
+            return useShortLabel ? "Padding" : "Layer Padding"
+        case .layerMargin:
+            return useShortLabel ? "Margin" : "Layer Margin"
+        case .offsetInGroup:
+            return useShortLabel ? "Offset" : "Offset in Group"
+        case .layerGroupAlignment:
+            return useShortLabel ? "Alignment" : "Children Alignment"
+        case .materialThickness:
+            return "Material"
+        case .deviceAppearance:
+            return useShortLabel ? "Appearance" : "Device Appearance"
+        case .scrollContentSize:
+            return useShortLabel ? "Content" : "Content Size"
+        case .scrollXEnabled:
+            return "Scroll X Enabled"
+        case .scrollJumpToXStyle:
+            return "Jump Style X"
+        case .scrollJumpToX:
+            return "Jump to X"
+        case .scrollJumpToXLocation:
+            return "Jump Position X"
+        case .scrollYEnabled:
+            return "Scroll Y Enabled"
+        case .scrollJumpToYStyle:
+            return "Jump Style Y"
+        case .scrollJumpToY:
+            return "Jump to Y"
+        case .scrollJumpToYLocation:
+            return "Jump Position Y"
+        case .anchorEntity:
+            return "Anchor Entity"
+        case .isEntityAnimating:
+            return "Animating"
+        case .translation3DEnabled:
+            return "Translation"
+        case .rotation3DEnabled:
+            return "Rotation"
+        case .scale3DEnabled:
+            return "Scale"
+        case .isMetallic:
+            return "Metallic"
+        case .transform3D:
+            return "3D Transform"
+        case .size3D:
+            return "Size 3D"
+        case .radius3D:
+            return "Radius"
+        case .height3D:
+            return "Height"
+        case .isScrollAuto:
+            return "Auto Scroll"
+        }
+    }
 }

--- a/Sources/StitchSchemaKit/V32/NodePort/Layer/LayerInputPort_V32.swift
+++ b/Sources/StitchSchemaKit/V32/NodePort/Layer/LayerInputPort_V32.swift
@@ -954,6 +954,20 @@ extension LayerInputPort_V32.LayerInputPort {
             return "Height"
         case .isScrollAuto:
             return "Auto Scroll"
+        case .beginEditing:
+            return "Begin Editing"
+        case .endEditing:
+            return "End Editing"
+        case .setText:
+            return "Set Text"
+        case .textToSet:
+            return "Text To Set"
+        case .isSecureEntry:
+            return "Secure Entry"
+        case .isSpellCheckEnabled:
+            return "Spellcheck Enabled"
+        case .keyboardType:
+            return "Keyboard Type"
         }
     }
 }

--- a/Sources/StitchSchemaKit/V32/Patch_V32.swift
+++ b/Sources/StitchSchemaKit/V32/Patch_V32.swift
@@ -514,3 +514,626 @@ extension Patch_V32.Patch: StitchVersionedCodable {
         }
     }
 }
+
+extension Patch_V32.Patch: NodeKindDescribable_V32.NodeKindDescribable {
+    public static let titleDisplay = "Patch"
+    
+    public func defaultDisplayTitle() -> String {
+        switch self {
+        case .splitter:
+            return "Value"
+        case .flipSwitch:
+            return "Switch"
+        case .arcTan2:
+            return "Arc Tan 2"
+        case .coreMLClassify:
+            return "Image Classification"
+        case .coreMLDetection:
+            return "Object Detection"
+        case .hslColor:
+            return "HSL Color"
+        case .colorToHSL:
+            return "Color to HSL"
+        case .rgba:
+            return "RGB Color"
+        case .colorToRGB:
+            return "Color to RGB"
+        case .arRaycasting:
+            return "Raycasting"
+        case .base64StringToImage:
+            return "Base64 to Image"
+        case .imageToBase64String:
+            return "Image to Base64"
+        case .whenPrototypeStarts:
+            return "On Prototype Start"
+        case .jsonToShape:
+            return "JSON to Shape"
+        case .jsonArray:
+            return "JSON Array"
+        case .jsonObject:
+            return "JSON Object"
+        case .arAnchor:
+            return "AR Anchor"
+        case .add:
+            return "Add"
+        case .convertPosition:
+            return "Convert Position"
+        case .dragInteraction:
+            return "Drag Interaction"
+        case .pressInteraction:
+            return "Press Interaction"
+        case .scrollInteraction:
+            return "Legacy Scroll Interaction"
+        case .repeatingPulse:
+            return "Repeating Pulse"
+        case .delay:
+            return "Delay"
+        case .pack:
+            return "Pack"
+        case .unpack:
+            return "Unpack"
+        case .counter:
+            return "Counter"
+        case .multiply:
+            return "Multiply"
+        case .optionPicker:
+            return "Option Picker"
+        case .loop:
+            return "Loop"
+        case .time:
+            return "Time"
+        case .deviceTime:
+            return "Device Time"
+        case .location:
+            return "Location"
+        case .random:
+            return "Random"
+        case .greaterOrEqual:
+            return "Greater or Equal"
+        case .lessThanOrEqual:
+            return "Less Than or Equal"
+        case .equals:
+            return "Equals"
+        case .restartPrototype:
+            return "Restart Prototype"
+        case .divide:
+            return "Divide"
+        case .or:
+            return "Or"
+        case .and:
+            return "And"
+        case .not:
+            return  "Not"
+        case .springAnimation:
+            return "Spring Animation"
+        case .popAnimation:
+            return "Pop Animation"
+        case .bouncyConverter:
+            return "Bouncy Converter"
+        case .optionSwitch:
+            return "Option Switch"
+        case .pulseOnChange:
+            return "Pulse on Change"
+        case .pulse:
+            return "Pulse"
+        case .classicAnimation:
+            return "Classic Animation"
+        case .cubicBezierAnimation:
+            return "Cubic Bezier Animation"
+        case .curve:
+            return "Curve"
+        case .cubicBezierCurve:
+            return "Cubic Bezier Curve"
+        case .repeatingAnimation:
+            return "Repeating Animation"
+        case .loopBuilder:
+            return "Loop Builder"
+        case .loopInsert:
+            return "Loop Insert"
+        case .transition:
+            return "Transition"
+        case .imageImport:
+            return "Image Import"
+        case .cameraFeed:
+            return "Camera Feed"
+        case .sampleAndHold:
+            return "Sample and Hold"
+        case .grayscale:
+            return "Grayscale"
+        case .loopSelect:
+            return "Loop Select"
+        case .videoImport:
+            return "Video Import"
+        case .sampleRange:
+            return "Sample Range"
+        case .soundImport:
+            return "Sound Import"
+        case .speaker:
+            return "Speaker"
+        case .microphone:
+            return "Microphone"
+        case .networkRequest:
+            return "Network Request"
+        case .valueForKey:
+            return "Value for Key"
+        case .valueAtIndex:
+            return "Value at Index"
+        case .loopOverArray:
+            return "Loop Over Array"
+        case .setValueForKey:
+            return "Set Value for Key"
+        case .arrayAppend:
+            return "Array Append"
+        case .arrayCount:
+            return "Array Count"
+        case .arrayJoin:
+            return "Array Join"
+        case .arrayReverse:
+            return "Array Reverse"
+        case .arraySort:
+            return "Array Sort"
+        case .getKeys:
+            return "Get Keys"
+        case .indexOf:
+            return "Index Of"
+        case .subarray:
+            return "Sub Array"
+        case .valueAtPath:
+            return "Value at Path"
+        case .deviceMotion:
+            return "Device Motion"
+        case .deviceInfo:
+            return "Device Info"
+        case .smoothValue:
+            return "Smooth Value"
+        case .velocity:
+            return "Velocity"
+        case .clip:
+            return "Clip"
+        case .max:
+            return "Max"
+        case .mod:
+            return "Mod"
+        case .absoluteValue:
+            return "Absolute Value"
+        case .round:
+            return "Round"
+        case .progress:
+            return "Progress"
+        case .reverseProgress:
+            return "Reverse Progress"
+        case .wirelessBroadcaster:
+            return "Wireless Broadcaster"
+        case .wirelessReceiver:
+            return "Wireless Receiver"
+        case .sine:
+            return "Sine"
+        case .cosine:
+            return "Cosine"
+        case .hapticFeedback:
+            return "Haptic Feedback"
+        case .soulver:
+            return "Soulver"
+        case .optionEquals:
+            return "Option Equals"
+        case .subtract:
+            return "Subtract"
+        case .squareRoot:
+            return "Square Root"
+        case .length:
+            return "Length"
+        case .min:
+            return "Min"
+        case .power:
+            return "Power"
+        case .equalsExactly:
+            return "Equals Exactly"
+        case .greaterThan:
+            return "Greater Than"
+        case .lessThan:
+            return "Less Than"
+        case .colorToHex:
+            return "Color to Hex"
+        case .hexColor:
+            return "Hex Color"
+        case .splitText:
+            return "Split Text"
+        case .textEndsWith:
+            return "Text Ends With"
+        case .textLength:
+            return "Text Length"
+        case .textReplace:
+            return "Text Replace"
+        case .textStartsWith:
+            return "Text Starts With"
+        case .textTransform:
+            return "Text Transform"
+        case .trimText:
+            return "Trim Text"
+        case .dateAndTimeFormatter:
+            return "Date And Time Formatter"
+        case .stopwatch:
+            return "Stopwatch"
+        case .optionSender:
+            return "Option Sender"
+        case .any:
+            return "Any"
+        case .loopCount:
+            return "Loop Count"
+        case .loopDedupe:
+            return "Loop Dedupe"
+        case .loopFilter:
+            return "Loop Filter"
+        case .loopOptionSwitch:
+            return "Loop Option Switch"
+        case .loopRemove:
+            return "Loop Remove"
+        case .loopReverse:
+            return "Loop Reverse"
+        case .loopShuffle:
+            return "Loop Shuffle"
+        case .loopSum:
+            return "Loop Sum"
+        case .loopToArray:
+            return "Loop to Array"
+        case .runningTotal:
+            return "Running Total"
+        case .layerInfo:
+            return "Layer Info"
+        case .triangleShape:
+            return "Triangle Shape"
+        case .circleShape:
+            return "Circle Shape"
+        case .ovalShape:
+            return "Oval Shape"
+        case .roundedRectangleShape:
+            return "Rounded Rectangle Shape"
+        case .union:
+            return "Union"
+        case .keyboard:
+            return "Keyboard"
+        case .shapeToCommands:
+            return "Shape to Commands"
+        case .commandsToShape:
+            return "Commands to Shape"
+        case .mouse:
+            return "Mouse"
+        case .qrCodeDetection:
+            return "QR Code Detection"
+        case .delayOne:
+            return "Delay 1"
+        case .javascript:
+            return "JavaScript"
+            // TODO: assume that rawValue for all patches added will have properly capitalized display-value, and so just use `default: return self.rawValue`
+        case .sizePack, .sizeUnpack, .positionPack, .positionUnpack, .point3DPack, .point3DUnpack, .point4DPack, .point4DUnpack, .transformPack, .transformUnpack, .closePath, .moveToPack, .lineToPack, .curveToPack, .curveToUnpack, .mathExpression, .springFromDurationAndBounce, .springFromResponseAndDampingRatio, .springFromSettlingDurationAndDampingRatio:
+            return self.rawValue
+        }
+    }
+    
+    public var aiNodeDescription: String {
+        switch self {
+        case .add:
+            return "Adds two numbers together."
+        case .subtract:
+            return "Subtracts one number from another."
+        case .multiply:
+            return "Multiplies two numbers together."
+        case .divide:
+            return "Divides one number by another."
+        case .mod:
+            return "Calculates the remainder of a division."
+        case .power:
+            return "Raises a number to the power of another."
+        case .squareRoot:
+            return "Calculates the square root of a number."
+        case .absoluteValue:
+            return "Finds the absolute value of a number."
+        case .round:
+            return "Rounds a number to the nearest integer."
+        case .max:
+            return "Finds the maximum of two numbers."
+        case .min:
+            return "Finds the minimum of two numbers."
+        case .length:
+            return "Calculates the length of a collection."
+        case .arcTan2:
+            return "Calculates the arctangent of a quotient."
+        case .sine:
+            return "Calculates the sine of an angle."
+        case .cosine:
+            return "Calculates the cosine of an angle."
+        case .clip:
+            return "Clips a value to a specified range."
+        case .or:
+            return "Logical OR operation."
+        case .and:
+            return "Logical AND operation."
+        case .not:
+            return "Logical NOT operation."
+        case .equals:
+            return "Checks if two values are equal."
+        case .equalsExactly:
+            return "Checks if two values are exactly equal."
+        case .greaterThan:
+            return "Checks if one value is greater than another."
+        case .greaterOrEqual:
+            return "Checks if one value is greater or equal to another."
+        case .lessThan:
+            return "Checks if one value is less than another."
+        case .lessThanOrEqual:
+            return "Checks if one value is less than or equal to another."
+        case .splitText:
+            return "Splits text into parts."
+        case .textLength:
+            return "Calculates the length of a text string."
+        case .textReplace:
+            return "Replaces text within a string."
+        case .textStartsWith:
+            return "Checks if text starts with a specific substring."
+        case .textEndsWith:
+            return "Checks if text ends with a specific substring."
+        case .textTransform:
+            return "Transforms text into a different format."
+        case .trimText:
+            return "Removes whitespace from the beginning and end of a text string."
+        case .time:
+            return "Returns number of seconds and frames since a prototype started."
+        case .dateAndTimeFormatter:
+            return "creates a human-readable date/time value from a time in seconds."
+        case .stopwatch:
+            return "measures elapsed time in seconds."
+        case .delay:
+            return "delays a value by a specified number of seconds."
+        case .delayOne:
+            return "delays incoming value by 1 frame."
+        case .imageImport:
+            return "imports an image asset."
+        case .videoImport:
+            return "imports a video asset."
+        case .soundImport:
+            return "imports an audio asset."
+        case .qrCodeDetection:
+            return "detects the value of a QR code from an image or video."
+        case .coreMLClassify:
+            return "performs image classification on an image or video."
+        case .coreMLDetection:
+            return "detects objects in an image or video."
+        case .cameraFeed:
+            return "creates a live camera feed."
+        case .deviceInfo:
+            return "gets info of the running device."
+        case .hapticFeedback:
+            return "generates haptic feedback."
+        case .keyboard:
+            return "handles keyboard input."
+        case .mouse:
+            return "handles mouse input."
+        case .microphone:
+            return "handles microphone input."
+        case .speaker:
+            return "handles audio speaker output."
+        case .dragInteraction:
+            return "detects a drag interaction."
+        case .pressInteraction:
+            return "detects a press interaction."
+        case .location:
+            return "gets the current location."
+        case .circleShape:
+            return "generates a circle shape."
+        case .ovalShape:
+            return "generates an oval shape."
+        case .roundedRectangleShape:
+            return "generates a rounded rectangle shape."
+        case .triangleShape:
+            return "generates a triangle shape."
+        case .shapeToCommands:
+            return "takes a shape as input, outputs the commands to generate the shape."
+        case .commandsToShape:
+            return "generates a shape from a given loop of shape commands."
+        case .transformPack:
+            return "packs inputs into a transform."
+        case .transformUnpack:
+            return "unpacks a transform."
+        case .moveToPack:
+            return "packs a position into a MoveTo shape command."
+        case .lineToPack:
+            return "packs a position into a LineTo shape command."
+        case .closePath:
+            return "ClosePath shape command."
+        case .base64StringToImage:
+            return "converts a base64 string to an image."
+        case .imageToBase64String:
+            return "converts an image to a base64 string."
+        case .colorToHSL:
+            return "converts a color to HSL components."
+        case .colorToRGB:
+            return "converts a color to RGB components."
+        case .colorToHex:
+            return "converts a color to a hex string."
+        case .hslColor:
+            return "generates a color from HSL components."
+        case .hexColor:
+            return "converts a hex string to a color."
+        case .grayscale:
+            return "applies grayscale effect to image/video."
+        case .splitter:
+            return "stores a value."
+        case .random:
+            return "generates a random value."
+        case .progress:
+            return "calculates progress value."
+        case .reverseProgress:
+            return "calculates inverse progress."
+        case .convertPosition:
+            return "converts position values between layers."
+        case .velocity:
+            return "measures velocity over time."
+        case .soulver:
+            return "evaluates plain-text math expressions."
+        case .whenPrototypeStarts:
+            return "fires pulse when prototype starts."
+        case .valueForKey:
+            return "extracts a value from JSON by key."
+        case .valueAtIndex:
+            return "extracts a value from JSON by index."
+        case .valueAtPath:
+            return "extracts a value from JSON by path."
+        case .pack:
+            return "creates a new value from inputs."
+        case .unpack:
+            return "splits a value into components."
+        case .sampleAndHold:
+            return "stores a value until new one is received."
+        case .sampleRange:
+            return "samples a range of values."
+        case .smoothValue:
+            return "smoothes input value."
+        case .runningTotal:
+            return "continuously sums values."
+        case .jsonToShape:
+            return "creates a Shape from JSON."
+        case .jsonArray:
+            return "creates a JSON array from inputs."
+        case .jsonObject:
+            return "creates a JSON object from key-value pairs."
+        case .bouncyConverter:
+            return "Converts bounce and duration values to spring animation parameters."
+        case .loopBuilder:
+            return "Creates a new loop with specified values."
+        case .loopFilter:
+            return "Filters elements in a loop based on a condition."
+        case .loopSelect:
+            return "Selects specific elements from a loop."
+        case .loopCount:
+            return "Counts the number of elements in a loop."
+        case .loopDedupe:
+            return "Removes duplicate elements from a loop."
+        case .loopOptionSwitch:
+            return "Switches between different loop options."
+        case .loopOverArray:
+            return "Iterates over elements in an array."
+        case .loopToArray:
+            return "Converts a loop into an array."
+        case .transition:
+            return "Controls transitions between states."
+        case .optionEquals:
+            return "Checks if an option equals a specific value."
+        case .curve:
+            return "Defines an animation curve."
+        case .cubicBezierCurve:
+            return "Creates a cubic bezier curve for animations."
+        case .any:
+            return "Returns true if any input is true."
+        case .rgba:
+            return "Creates a color from RGBA components."
+        case .arrayJoin:
+            return "Joins array elements into a string."
+        case .getKeys:
+            return "Gets all keys from an object."
+        case .indexOf:
+            return "Gets the index of an element in an array."
+        case .positionUnpack:
+            return "Unpacks a position into X and Y components."
+        case .point3DUnpack:
+            return "Unpacks a 3D point into X, Y, and Z components."
+        case .point4DUnpack:
+            return "Unpacks a 4D point into X, Y, Z, and W components."
+        case .mathExpression:
+            return "Evaluates a mathematical expression."
+        case .setValueForKey:
+            return "Sets a value for a specified key in an object."
+        case .springAnimation:
+            return "Creates an animation based off of the physical model of a spring"
+        case .popAnimation:
+            return " Animates a value using a spring effect."
+        case .classicAnimation:
+            return "Animates a number using a standard animation curve."
+        case .cubicBezierAnimation:
+            return "Creates custom animation curves by defining two control points"
+        case .repeatingAnimation:
+            return "Repeatedly animates a number."
+        case .pulse:
+            return "Outputs a pulse event when it's toggled on or off."
+        case .pulseOnChange:
+            return "The Pulse On Change node outputs a pulse if an input value comes in that i different from the specified value."
+        case .repeatingPulse:
+            return "A node that will fire a pulse at a defined interval."
+        case .union:
+            return "Combines two or more shapes to generate a new shape."
+        case .arrayAppend:
+            return " This node appends to the end of the provided array."
+        case .arrayCount:
+            return "This node returns the number of items in an array."
+        case .subarray:
+            return "Returns a subarray from a given array."
+        case .arraySort:
+            return "This node sorts the array in ascending order."
+        case .arrayReverse:
+            return "This node reverses the order of the items in the array."
+        case .scrollInteraction:
+            return "Adds scroll interaction to a specified layer."
+        case .arAnchor:
+            return "Creates an AR anchor from a 3D model and an ARTransform. Represents the positio and orientation of a 3D item in the physical environment."
+        case .arRaycasting:
+            return "Returns a 3D location in physical space that corresponds to a given 2D location o the screen."
+        case .deviceTime:
+            return "Returns the current time of the device your prototype is running on."
+        case .deviceMotion:
+            return "Returns the acceleration and rotation values of the device the patch is running on."
+        case .wirelessBroadcaster:
+            return "Sends a value to a selected Wireless Receiver node. Useful for organizing large complicated projects by replacing cables between patches."
+        case .wirelessReceiver:
+            return "-Used with the Wireless Broadcaster node to route values across the graph. Useful fo organizing large, complicated projects."
+        case .restartPrototype:
+            return "A node that will restart the state of your prototype. All inputs and outputs of th nodes on your graph will be reset."
+        case .optionPicker:
+            return "The Option Picker node lets you cycle through and select one of N inputs to use a the output. Multiple inputs can be added and removed from the node, and it can be configured to work with a variety of node types."
+        case .optionSender:
+            return "Used to pick an output to send a value to. Multiple value types can be used wit this node."
+        case .optionSwitch:
+            return "Used to control two or more states with an index value. N number of inputs can b added to the node."
+        case .counter:
+            return "Counter that can be incremented, decremented, or set to a specified value. Starts at 0."
+        case .flipSwitch:
+            return "A node that will flip between an On and Off state whenever a pulse is received."
+        case .loop:
+            return "Generate a loop of indices. For example, an input of 3 outputs a loop of [0, 1, 2]."
+        case .loopInsert:
+            return "Insert a new value at a particular index in a loop."
+        case .networkRequest:
+            return "The Network Request node allows you to make HTTP GET and POST requests to an endpoint. Results are returned as JSON."
+        case .loopRemove:
+            return "Removes a value from a specified index in a loop."
+        case .loopReverse:
+            return "Reverse the order of the values in a loop"
+        case .loopShuffle:
+            return "Randomly reorders the values in a loop."
+        case .loopSum:
+            return "Calculates the sum of every value in a loop."
+        case .layerInfo:
+            return "Returns information about a specified layer."
+        case .sizePack:
+            return "Packs two Layer Dimension inputs to a single Layer Size output."
+        case .sizeUnpack:
+            return "Unpacks a single Layer Size input to two Layer Size outputs."
+        case .positionPack:
+            return "Packs two Number inputs to a single Position output."
+        case .point3DPack:
+            return "Packs three Number inputs to a single Point3D output."
+        case .point4DPack:
+            return "Packs four Number inputs to a single Point4D output."
+        case .curveToPack:
+            return "Packs Point, CurveTo and CurveFrom position inputs into a CurveTo ShapeCommand."
+        case .curveToUnpack:
+            return "Unpack packs CurveTo ShapeCommand into a Point, CurveTo and CurveFrom position outputs."
+        case .springFromDurationAndBounce:
+            return "Convert duration and bounce values to mass, stiffness and damping for a Spring Animation node."
+        case .springFromResponseAndDampingRatio:
+            return "Convert response and damping ratio to mass, stiffness and damping for a Spring Animation node."
+        case .springFromSettlingDurationAndDampingRatio:
+            return "Convert settling duration and damping ratio to mass, stiffness and damping for a Spring Animation node."
+        case .javascript:
+            return "A node that uses JavaScript code underneath the hood. Can be created using Stitch AI."
+        }
+    }
+}

--- a/Sources/StitchSchemaKit/V32/PortValueTypes/LayerDimension_V32.swift
+++ b/Sources/StitchSchemaKit/V32/PortValueTypes/LayerDimension_V32.swift
@@ -51,3 +51,27 @@ extension LayerDimension_V32.LayerDimension: StitchVersionedCodable {
         }
     }
 }
+
+extension LayerDimension_V32.LayerDimension: CustomStringConvertible {
+    public static let AUTO_SIZE_STRING = "auto"
+    public static let FILL_SIZE_STRING = "fill"
+    public static let HUG_SIZE_STRING = "hug"
+    
+    // MARK: string coercison causes perf loss (GitHub issue #3120)
+    public var description: String {
+        switch self {
+        case .auto:
+            return Self.AUTO_SIZE_STRING
+        case .parentPercent(let x):
+            //            return "\(x.coerceToUserFriendlyString)%"
+            return "\(x.description)%"
+        case .number(let x):
+            //            return x.coerceToUserFriendlyString
+            return x.description
+        case .fill:
+            return Self.FILL_SIZE_STRING
+        case .hug:
+            return Self.HUG_SIZE_STRING
+        }
+    }
+}

--- a/Sources/StitchSchemaKit/V32/UserVisibleType_V32.swift
+++ b/Sources/StitchSchemaKit/V32/UserVisibleType_V32.swift
@@ -324,6 +324,8 @@ extension UserVisibleType_V32.UserVisibleType {
             return "Device Appearance"
         case .anchorEntity:
             return "Anchor Entity"
+        case .keyboardType:
+            return "Keyboard Type"
         }
     }
     

--- a/Sources/StitchSchemaKit/V32/UserVisibleType_V32.swift
+++ b/Sources/StitchSchemaKit/V32/UserVisibleType_V32.swift
@@ -194,3 +194,144 @@ extension UserVisibleType_V32.UserVisibleType: StitchVersionedCodable {
         }
     }
 }
+
+extension UserVisibleType_V32.UserVisibleType {
+    public init?(llmString: String) {
+        guard let match = Self.allCases.first(where: {
+            $0.asLLMStepNodeType == Self.toCamelCase(llmString)
+        }) else {
+            return nil
+        }
+        
+        self = match
+    }
+    
+    // TODO: our OpenAI schema does not define all possible node-types, and those node types that we do define use camelCase
+    // TODO: some node types use human-readable strings ("Sizing Scenario"), not camelCase ("sizingScenario") as their raw value; so can't use `NodeType(rawValue:)` constructor
+    public var asLLMStepNodeType: String {
+        Self.toCamelCase(self.display)
+    }
+    
+    public var display: String {
+        switch self {
+        case .string:
+            return "String"
+        case .bool:
+            return "Bool"
+        case .color:
+            return "Color"
+        case .number:
+            return "Number"
+        case .layerDimension:
+            return "Layer Dimension"
+        case .size:
+            return "Size"
+        case .position:
+            return "Position"
+        case .point3D:
+            return "3D Point"
+        case .point4D:
+            return "4D Point"
+        case .transform:
+            return "Transform"
+        case .plane:
+            return "Plane"
+        case .pulse:
+            return "Pulse"
+        case .media:
+            return "Media"
+        case .json:
+            return "JSON"
+        case .networkRequestType:
+            return "Network Request Type"
+        case .none:
+            return "None"
+        case .anchoring:
+            return "Anchor"
+        case .cameraDirection:
+            return "Camera Direction"
+        case .interactionId:
+            return "Layer"
+        case .scrollMode:
+            return "Scroll Mode"
+        case .textAlignment:
+            return "Text Horizontal Alignment"
+        case .textVerticalAlignment:
+            return "Text Vertical Alignment"
+        case .fitStyle:
+            return "Fit"
+        case .animationCurve:
+            return "Animation Curve"
+        case .lightType:
+            return "Light Type"
+        case .layerStroke:
+            return "Layer Stroke"
+        case .textTransform:
+            return "Text Transform"
+        case .dateAndTimeFormat:
+            return "Date and Time Format"
+        case .shape:
+            return "Shape"
+        case .scrollJumpStyle:
+            return "Scroll Jump Style"
+        case .scrollDecelerationRate:
+            return "Scroll Deceleration Rate"
+        case .delayStyle:
+            return "Delay Style"
+        case .shapeCoordinates:
+            return "Shape Coordinates"
+        case .shapeCommand:
+            return "Shape Command"
+        case .shapeCommandType:
+            return "Shape Command Type"
+        case .orientation:
+            return "Orientation"
+        case .cameraOrientation:
+            return "Camera Orientation"
+        case .deviceOrientation:
+            return "Device Orientation"
+        case .vnImageCropOption:
+            return "Image Crop & Scale"
+        case .textDecoration:
+            return "Text Decoration"
+        case .textFont:
+            return "Text Font"
+        case .blendMode:
+            return "Blend Mode"
+        case .mapType:
+            return "Map Type"
+        case .progressIndicatorStyle:
+            return "Progress Style"
+        case .mobileHapticStyle:
+            return "Haptic Style"
+        case .strokeLineCap:
+            return "Stroke Line Cap"
+        case .strokeLineJoin:
+            return "Stroke Line Join"
+        case .contentMode:
+            return "Content Mode"
+        case .spacing:
+            return "Spacing"
+        case .padding:
+            return "Padding"
+        case .sizingScenario:
+            return "Sizing Scenario"
+        case .pinToId:
+            return "Pin To ID"
+        case .materialThickness:
+            return "Materialize Thickness"
+        case .deviceAppearance:
+            return "Device Appearance"
+        case .anchorEntity:
+            return "Anchor Entity"
+        }
+    }
+    
+    private static func toCamelCase(_ sentence: String) -> String {
+        let words = sentence.components(separatedBy: " ")
+        let camelCaseString = words.enumerated().map { index, word in
+            index == 0 ? word.lowercased() : word.capitalized
+        }.joined()
+        return camelCaseString
+    }
+}


### PR DESCRIPTION
Reattempting #132.

The goal of this PR is to provide baseline support for a newly-versioned schema for Stitch AI. Stitch AI's schema is versioned asynchronously from SSK, and thus support for some helpers has been moved here, where future versions will copy said helpers ensuring AI support.

Additionally, changes were made to migration helpers to better expose functionality for migrating decoded types. Previously, the migration flow always started from a document URL, but now the API has been expanded to support known types.