### PR TITLE
Moved helpers from Stitch to SSK for AI migration

### DIFF
--- a/Sources/StitchSchemaKit/V31/NodePort/PortValue_V31.swift
+++ b/Sources/StitchSchemaKit/V31/NodePort/PortValue_V31.swift
@@ -257,3 +257,14 @@ extension PortValue_V31.PortValue: StitchVersionedCodable {
         }
     }
 }
+
+// MARK: - helpers below are needed for both SSK and AI. Managed here to ensure all versions include this logic.
+
+extension PortValue_V31.PortValue {
+    var getInteractionId: LayerNodeId_V31.LayerNodeId? {
+        switch self {
+        case .assignedLayer(let x): return x
+        default: return nil
+        }
+    }
+}

--- a/Sources/StitchSchemaKit/V31/NodePort/PortValue_V31.swift
+++ b/Sources/StitchSchemaKit/V31/NodePort/PortValue_V31.swift
@@ -261,7 +261,7 @@ extension PortValue_V31.PortValue: StitchVersionedCodable {
 // MARK: - helpers below are needed for both SSK and AI. Managed here to ensure all versions include this logic.
 
 extension PortValue_V31.PortValue {
-    var getInteractionId: LayerNodeId_V31.LayerNodeId? {
+    public var getInteractionId: LayerNodeId_V31.LayerNodeId? {
         switch self {
         case .assignedLayer(let x): return x
         default: return nil

--- a/Sources/StitchSchemaKit/V31/PortValueTypes/LayerNodeId_V31.swift
+++ b/Sources/StitchSchemaKit/V31/PortValueTypes/LayerNodeId_V31.swift
@@ -29,4 +29,8 @@ extension LayerNodeId_V31.LayerNodeId: StitchVersionedCodable {
     public init(previousInstance: LayerNodeId_V31.PreviousInstance) {
         self.init(previousInstance.id)
     }
+    
+    public var asNodeId: UUID {
+        self.id
+    }
 }

--- a/Sources/StitchSchemaKit/V32/NodePort/PortValue_V32.swift
+++ b/Sources/StitchSchemaKit/V32/NodePort/PortValue_V32.swift
@@ -262,7 +262,7 @@ extension PortValue_V32.PortValue: StitchVersionedCodable {
 // MARK: - helpers below are needed for both SSK and AI. Managed here to ensure all versions include this logic.
 
 extension PortValue_V32.PortValue {
-    var getInteractionId: LayerNodeId_V32.LayerNodeId? {
+    public var getInteractionId: LayerNodeId_V32.LayerNodeId? {
         switch self {
         case .assignedLayer(let x): return x
         default: return nil

--- a/Sources/StitchSchemaKit/V32/NodePort/PortValue_V32.swift
+++ b/Sources/StitchSchemaKit/V32/NodePort/PortValue_V32.swift
@@ -258,3 +258,14 @@ extension PortValue_V32.PortValue: StitchVersionedCodable {
         }
     }
 }
+
+// MARK: - helpers below are needed for both SSK and AI. Managed here to ensure all versions include this logic.
+
+extension PortValue_V32.PortValue {
+    var getInteractionId: LayerNodeId_V32.LayerNodeId? {
+        switch self {
+        case .assignedLayer(let x): return x
+        default: return nil
+        }
+    }
+}

--- a/Sources/StitchSchemaKit/V32/PortValueTypes/LayerNodeId_V32.swift
+++ b/Sources/StitchSchemaKit/V32/PortValueTypes/LayerNodeId_V32.swift
@@ -29,4 +29,8 @@ extension LayerNodeId_V32.LayerNodeId: StitchVersionedCodable {
     public init(previousInstance: LayerNodeId_V32.PreviousInstance) {
         self.init(previousInstance.id)
     }
+    
+    public var asNodeId: UUID {
+        self.id
+    }
 }


### PR DESCRIPTION
Small changes to make AI schema migrations easier. By moving helpers here we guarantee every version comes with certain helpers used in AI land.